### PR TITLE
feat/#4: 상품 재고 화면에 카테고리 Chip 필터 추가

### DIFF
--- a/src/commons/ui/Chip.tsx
+++ b/src/commons/ui/Chip.tsx
@@ -1,0 +1,67 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../lib';
+
+/* ------------------------------------------------------------------------------------------------- */
+/* Root */
+/* ------------------------------------------------------------------------------------------------- */
+
+const chipVariants = cva(
+  'inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors duration-150 select-none disabled:pointer-events-none disabled:border-gray-200 disabled:bg-gray-100 disabled:text-gray-400',
+  {
+    variants: {
+      selected: {
+        true: 'border-emerald-600 bg-emerald-600 text-white',
+        false: 'border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50',
+      },
+    },
+    defaultVariants: {
+      selected: false,
+    },
+  },
+);
+
+interface ChipProps
+  extends Omit<React.ComponentProps<'button'>, 'onChange'>,
+    VariantProps<typeof chipVariants> {
+  /** 선택 상태 */
+  selected?: boolean;
+  /** 선택 상태 변경 핸들러 */
+  onSelectedChange?: (selected: boolean) => void;
+}
+
+function Chip({ className, selected = false, onSelectedChange, onClick, disabled, ...props }: ChipProps) {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onSelectedChange?.(!selected);
+    onClick?.(e);
+  };
+
+  return (
+    <button
+      data-slot="chip"
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      disabled={disabled}
+      onClick={handleClick}
+      className={cn(chipVariants({ selected, className }))}
+      {...props}
+    />
+  );
+}
+
+/* ------------------------------------------------------------------------------------------------- */
+/* Row */
+/* ------------------------------------------------------------------------------------------------- */
+
+function ChipRow({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="chip-row"
+      className={cn('flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden', className)}
+      {...props}
+    />
+  );
+}
+
+export { Chip, ChipRow, chipVariants };

--- a/src/commons/ui/index.ts
+++ b/src/commons/ui/index.ts
@@ -6,6 +6,7 @@ export { BottomSheet } from './BottomSheet';
 export { Button, buttonVariants } from './Button';
 export { Calendar } from './Calendar';
 export { Card } from './Card';
+export { Chip, ChipRow, chipVariants } from './Chip';
 export { CTAButton, CTAConfirmButton } from './CTAButton';
 export { Command } from './Command';
 export { ComboBox, type ComboBoxProps } from './ComboBox';

--- a/src/features/fridge/index.ts
+++ b/src/features/fridge/index.ts
@@ -23,3 +23,4 @@ export { FridgeBatchAddBottomSheet } from './ui/FridgeBatchAddBottomSheet';
 export { FridgeBatchEditScreen } from './ui/FridgeBatchEditScreen';
 export { FridgeFilterSettingsScreen } from './ui/FridgeFilterSettingsScreen';
 export { FridgeSearch } from './ui/FridgeSearch';
+export { FridgeCategoryFilter, ALL_CATEGORY_ID } from './ui/FridgeCategoryFilter';

--- a/src/features/fridge/ui/FridgeCategoryFilter.tsx
+++ b/src/features/fridge/ui/FridgeCategoryFilter.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Chip, ChipRow } from '@/commons/ui';
+
+import { type IngredientCategoryOption } from '@/entities/ingredient-category';
+
+const ALL_CATEGORY_ID = 'all';
+
+interface FridgeCategoryFilterProps {
+  categories: IngredientCategoryOption[];
+  selectedCategoryId: string;
+  onCategoryChange: (categoryId: string) => void;
+}
+
+export function FridgeCategoryFilter({
+  categories,
+  selectedCategoryId,
+  onCategoryChange,
+}: FridgeCategoryFilterProps) {
+  return (
+    <ChipRow role="radiogroup" aria-label="카테고리 필터">
+      <Chip
+        selected={selectedCategoryId === ALL_CATEGORY_ID}
+        onSelectedChange={() => onCategoryChange(ALL_CATEGORY_ID)}
+      >
+        전체
+      </Chip>
+      {categories.map((category) => (
+        <Chip
+          key={category.id}
+          selected={selectedCategoryId === category.id}
+          onSelectedChange={() => onCategoryChange(category.id)}
+        >
+          <span className="font-tossface" aria-hidden>
+            {category.emoji}
+          </span>
+          {category.label}
+        </Chip>
+      ))}
+    </ChipRow>
+  );
+}
+
+export { ALL_CATEGORY_ID };

--- a/src/pages/fridge/ui/FridgePage.tsx
+++ b/src/pages/fridge/ui/FridgePage.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import { Plus } from 'lucide-react';
 import { parseAsString, useQueryState } from 'nuqs';
 import { overlay } from 'overlay-kit';
@@ -11,10 +13,13 @@ import { Button } from '@/commons/ui';
 
 import { type FridgeItemBatch, type FridgeItemWithBatches } from '@/entities/fridge-item';
 import { type IngredientUnit } from '@/entities/ingredient';
+import { useIngredientCategory } from '@/entities/ingredient-category';
 
 import {
+  ALL_CATEGORY_ID,
   ExpiryBanner,
   FridgeBatchAddBottomSheet,
+  FridgeCategoryFilter,
   FridgeItemList,
   FridgeSearch,
   useFridgeItemsQuery,
@@ -35,12 +40,20 @@ export function FridgePage({ householdId }: FridgePageProps) {
       },
     }),
   );
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string>(ALL_CATEGORY_ID);
+
   const { data: user } = useUserSuspenseQuery();
   const { data: items = [], isLoading } = useFridgeItemsQuery({
     householdId,
     userId: user.id,
     searchInput: searchValue,
   });
+  const { categories } = useIngredientCategory(householdId);
+
+  const filteredItems =
+    selectedCategoryId === ALL_CATEGORY_ID
+      ? items
+      : items.filter((item) => item.category_id === selectedCategoryId);
 
   const createOverlayCloseHandler = (close: () => void, unmount: () => void) => {
     close();
@@ -79,6 +92,10 @@ export function FridgePage({ householdId }: FridgePageProps) {
     await setSearchValue(value);
   }
 
+  function changeCategoryFilter(categoryId: string) {
+    setSelectedCategoryId(categoryId);
+  }
+
   return (
     <div className="flex flex-col gap-4 px-4 pb-5">
       {/* 만료 임박 배너 */}
@@ -86,6 +103,15 @@ export function FridgePage({ householdId }: FridgePageProps) {
 
       {/* 검색 */}
       <FridgeSearch value={searchValue} onChange={changeSearchValue} />
+
+      {/* 카테고리 Chip 필터 */}
+      {categories.length > 0 && (
+        <FridgeCategoryFilter
+          categories={categories}
+          selectedCategoryId={selectedCategoryId}
+          onCategoryChange={changeCategoryFilter}
+        />
+      )}
 
       {/* 리스트 */}
       {isLoading ? (
@@ -95,7 +121,7 @@ export function FridgePage({ householdId }: FridgePageProps) {
       ) : (
         <FridgeItemList
           householdId={householdId}
-          items={items}
+          items={filteredItems}
           isSearching={Boolean(searchValue.trim())}
           onEditItem={openFridgeItemEditSheet}
           onAddBatch={openFridgeBatchAddSheet}


### PR DESCRIPTION
## 개요

closes #4

상품 재고 목록 상단에 카테고리 기반 Chip 필터 UI를 추가합니다.

## 변경 사항

### commons/ui/Chip.tsx (신규)
- `Chip` 컴포넌트: 단일 선택(radio) 방식의 공통 Chip UI
  - `selected`, `onSelectedChange`, `disabled` 상태 지원
  - `cva` 기반 스타일 (선택됨: emerald, 미선택: gray)
  - `role="radio"`, `aria-checked` 접근성 속성 포함
- `ChipRow` 컴포넌트: 가로 스크롤 가능한 Chip 컨테이너
  - 스크롤바 숨김 처리 (webkit/firefox/ie 크로스브라우저)

### features/fridge/ui/FridgeCategoryFilter.tsx (신규)
- 카테고리 Chip 필터 Row 컴포넌트
- "전체" Chip을 기본 선택 상태로 표시
- 각 카테고리 Chip 클릭 시 `onCategoryChange` 콜백 호출
- emoji + label 형태로 카테고리 표시

### pages/fridge/ui/FridgePage.tsx (수정)
- `selectedCategoryId` 상태 추가 (기본값: `'all'`)
- `useIngredientCategory` 훅으로 카테고리 목록 조회
- `filteredItems` 계산: 전체 선택 시 원본 목록, 카테고리 선택 시 해당 카테고리 아이템만 필터링
- 카테고리가 있을 때만 `FridgeCategoryFilter` 렌더링

## 스크린샷

카테고리 Chip 필터가 검색창 아래에 위치하며, 가로 스크롤로 전체 카테고리를 탐색할 수 있습니다.

## 테스트 계획

- [ ] 전체 Chip 선택 시 모든 재고 아이템이 표시되는지 확인
- [ ] 특정 카테고리 Chip 선택 시 해당 카테고리 아이템만 필터링되는지 확인
- [ ] 카테고리가 많을 때 가로 스크롤이 정상 동작하는지 확인
- [ ] 검색과 카테고리 필터 동시 사용 시 정상 동작하는지 확인
- [ ] Chip의 선택/미선택 스타일이 올바르게 표시되는지 확인