### PR TITLE
fix/#12: 카테고리 칩 필터로 인한 모바일 레이아웃 너비 깨짐 수정

### DIFF
--- a/src/commons/ui/Chip.tsx
+++ b/src/commons/ui/Chip.tsx
@@ -58,7 +58,10 @@ function ChipRow({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="chip-row"
-      className={cn('flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden', className)}
+      className={cn(
+        'flex min-w-0 gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+        className,
+      )}
       {...props}
     />
   );

--- a/src/pages/fridge/ui/FridgePage.tsx
+++ b/src/pages/fridge/ui/FridgePage.tsx
@@ -97,7 +97,7 @@ export function FridgePage({ householdId }: FridgePageProps) {
   }
 
   return (
-    <div className="flex flex-col gap-4 px-4 pb-5">
+    <div className="flex flex-col gap-4 overflow-x-clip px-4 pb-5">
       {/* 만료 임박 배너 */}
       {!searchValue.trim() && <ExpiryBanner items={items} />}
 


### PR DESCRIPTION
## 연관 이슈

closes #12

## 변경 내용

### 원인

이슈 #4에서 추가된 카테고리 칩 필터(`FridgeCategoryFilter`)가 flex 레이아웃 내에서 컨텐츠 크기만큼 컨테이너를 강제 확장하여 모바일 뷰포트 너비가 깨지는 문제가 발생했습니다.

- `ChipRow`에 `min-w-0`이 없어 flex 자식으로 사용될 때 내부 칩 목록의 전체 너비만큼 부모 레이아웃이 늘어남
- `FridgePage` 외부 컨테이너에 가로 방향 overflow 제어가 없어 뷰포트 바깥까지 레이아웃이 확장됨

### 수정

- `ChipRow`에 `min-w-0` 추가: flex 자식으로 배치될 때 자신의 최소 너비를 0으로 제한하여 부모 컨테이너 너비 범위 내에서 렌더링
- `FridgePage` 컨테이너에 `overflow-x-clip` 추가: 가로 방향 overflow 콘텐츠를 클리핑하여 뷰포트 바깥 레이아웃 확장 방지

## 테스트 체크리스트

- [ ] 모바일 화면에서 카테고리 칩 목록이 수평 스크롤로 동작하는지 확인
- [ ] 칩 목록으로 인해 전체 페이지 가로 스크롤이 발생하지 않는지 확인
- [ ] 카테고리 필터 선택 후 재고 목록이 정상적으로 필터링되는지 확인
- [ ] FAB 버튼 및 기타 UI 요소에 레이아웃 영향이 없는지 확인