### PR TITLE
feat/#24: 삭제 액션에 확인 BottomSheet 추가

### DIFF
--- a/src/commons/ui/DeleteConfirmBottomSheet.tsx
+++ b/src/commons/ui/DeleteConfirmBottomSheet.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { BottomSheet } from './BottomSheet';
+import { Button } from './Button';
+
+/* -------------------------------------------------------------------------------------------------
+ * DeleteConfirmBottomSheet
+ * 삭제 전 사용자 확인을 요청하는 BottomSheet.
+ * overlay-kit과 함께 사용하거나 controlled 방식으로도 사용할 수 있다.
+ * -----------------------------------------------------------------------------------------------*/
+interface DeleteConfirmBottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title?: ReactNode;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  isPending?: boolean;
+}
+
+/**
+ * @description 삭제 액션 전 사용자 확인을 요청하는 BottomSheet 컴포넌트.
+ * overlay-kit의 overlay.open() 패턴과 함께 사용하거나 controlled 방식으로도 사용할 수 있다.
+ */
+function DeleteConfirmBottomSheet({
+  open,
+  onClose,
+  onConfirm,
+  title = '정말 삭제하시겠습니까?',
+  description,
+  confirmLabel = '삭제',
+  cancelLabel = '취소',
+  isPending = false,
+}: DeleteConfirmBottomSheetProps) {
+  return (
+    <BottomSheet open={open} onClose={onClose} handleOnly={false}>
+      <BottomSheet.Header heading={title} />
+      <BottomSheet.Content className="space-y-2">
+        {description ? (
+          <p className="text-muted-foreground text-center text-sm">{description}</p>
+        ) : null}
+        <div className="flex gap-2 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            color="mono"
+            className="flex-1"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            className="flex-1"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </BottomSheet.Content>
+    </BottomSheet>
+  );
+}
+
+export { DeleteConfirmBottomSheet, type DeleteConfirmBottomSheetProps };

--- a/src/commons/ui/index.ts
+++ b/src/commons/ui/index.ts
@@ -8,6 +8,10 @@ export { Button, buttonVariants } from './Button';
 export { Calendar } from './Calendar';
 export { Card } from './Card';
 export { ConfirmDialog, type ConfirmDialogProps } from './ConfirmDialog';
+export {
+  DeleteConfirmBottomSheet,
+  type DeleteConfirmBottomSheetProps,
+} from './DeleteConfirmBottomSheet';
 export { Chip, ChipRow, chipVariants } from './Chip';
 export { CTAButton, CTAConfirmButton } from './CTAButton';
 export { Command } from './Command';

--- a/src/features/fridge/ui/FridgeBatchEditScreen.tsx
+++ b/src/features/fridge/ui/FridgeBatchEditScreen.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { AppScreen } from '@stackflow/plugin-basic-ui';
+import { overlay } from 'overlay-kit';
 
-import { CTAConfirmButton, Toast } from '@/commons/ui';
+import { CTAConfirmButton, DeleteConfirmBottomSheet, Toast } from '@/commons/ui';
 
 import { type FridgeItemBatch } from '@/entities/fridge-item';
 import { type IngredientUnit } from '@/entities/ingredient';
@@ -60,8 +61,6 @@ export function FridgeBatchEditScreen({
   }
 
   function deleteBatch() {
-    if (!window.confirm('이 재고를 삭제하시겠습니까?')) return;
-
     deleteMutation.mutate(batch.id, {
       onSuccess: () => {
         Toast.success('재고가 삭제되었습니다');
@@ -70,6 +69,30 @@ export function FridgeBatchEditScreen({
       onError: (error) => {
         Toast.error(getErrorMessage(error));
       },
+    });
+  }
+
+  function openDeleteConfirm() {
+    overlay.open(({ isOpen, close, unmount }) => {
+      function closeSheet() {
+        close();
+        window.setTimeout(unmount, 200);
+      }
+
+      function confirmDelete() {
+        closeSheet();
+        deleteBatch();
+      }
+
+      return (
+        <DeleteConfirmBottomSheet
+          open={isOpen}
+          onClose={closeSheet}
+          onConfirm={confirmDelete}
+          title="재고를 삭제하시겠습니까?"
+          description="삭제된 재고는 복구할 수 없습니다."
+        />
+      );
     });
   }
 
@@ -100,7 +123,7 @@ export function FridgeBatchEditScreen({
           color="danger"
           variant="subtle"
           disabled={Boolean(mutation.isPending || deleteMutation.isPending)}
-          onClick={deleteBatch}
+          onClick={openDeleteConfirm}
         >
           삭제
         </CTAConfirmButton.Left>

--- a/src/features/fridge/ui/FridgeItemEditScreen.tsx
+++ b/src/features/fridge/ui/FridgeItemEditScreen.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { AppScreen } from '@stackflow/plugin-basic-ui';
+import { overlay } from 'overlay-kit';
 
-import { CTAConfirmButton, Toast } from '@/commons/ui';
+import { CTAConfirmButton, DeleteConfirmBottomSheet, Toast } from '@/commons/ui';
 
 import { type FridgeItemWithBatches } from '@/entities/fridge-item';
 
@@ -61,6 +62,30 @@ export function FridgeItemEditScreen({ onClose, item }: FridgeItemEditScreenProp
     });
   }
 
+  function openDeleteConfirm() {
+    overlay.open(({ isOpen, close, unmount }) => {
+      function closeSheet() {
+        close();
+        window.setTimeout(unmount, 200);
+      }
+
+      function confirmDelete() {
+        closeSheet();
+        deleteItem();
+      }
+
+      return (
+        <DeleteConfirmBottomSheet
+          open={isOpen}
+          onClose={closeSheet}
+          onConfirm={confirmDelete}
+          title="재료를 삭제하시겠습니까?"
+          description="삭제된 재료는 복구할 수 없습니다."
+        />
+      );
+    });
+  }
+
   return (
     <AppScreen className="pointer-events-auto" appBar={{ title: '재료 수정' }}>
       <div className="px-4 pt-4 pb-28">
@@ -87,7 +112,7 @@ export function FridgeItemEditScreen({ onClose, item }: FridgeItemEditScreenProp
           color="danger"
           variant="subtle"
           disabled={Boolean(mutation.isPending || deleteMutation.isPending)}
-          onClick={deleteItem}
+          onClick={openDeleteConfirm}
         >
           삭제
         </CTAConfirmButton.Left>

--- a/src/features/ingredient/ui/IngredientEditScreen.tsx
+++ b/src/features/ingredient/ui/IngredientEditScreen.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { AppScreen } from '@stackflow/plugin-basic-ui';
+import { overlay } from 'overlay-kit';
 
-import { CTAConfirmButton, Toast } from '@/commons/ui';
+import { CTAConfirmButton, DeleteConfirmBottomSheet, Toast } from '@/commons/ui';
 
 import { type Ingredient } from '@/entities/ingredient';
 
@@ -69,6 +70,30 @@ export function IngredientEditScreen({
     });
   }
 
+  function openDeleteConfirm() {
+    overlay.open(({ isOpen, close, unmount }) => {
+      function closeSheet() {
+        close();
+        window.setTimeout(unmount, 200);
+      }
+
+      function confirmDelete() {
+        closeSheet();
+        deleteIngredient();
+      }
+
+      return (
+        <DeleteConfirmBottomSheet
+          open={isOpen}
+          onClose={closeSheet}
+          onConfirm={confirmDelete}
+          title="상품을 삭제하시겠습니까?"
+          description="삭제된 상품은 복구할 수 없습니다."
+        />
+      );
+    });
+  }
+
   return (
     <AppScreen className="pointer-events-auto" appBar={{ title: '상품 수정' }}>
       <div className="px-4 pt-4 pb-28">
@@ -99,7 +124,7 @@ export function IngredientEditScreen({
           color="danger"
           variant="subtle"
           disabled={Boolean(updateMutation.isPending || deleteMutation.isPending)}
-          onClick={deleteIngredient}
+          onClick={openDeleteConfirm}
         >
           삭제
         </CTAConfirmButton.Left>

--- a/src/features/meal/ui/MealEditorScreen.tsx
+++ b/src/features/meal/ui/MealEditorScreen.tsx
@@ -6,10 +6,11 @@ import { useForm } from '@tanstack/react-form';
 import { format, parseISO } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { Plus } from 'lucide-react';
+import { overlay } from 'overlay-kit';
 import { z } from 'zod';
 
 import { extractFieldErrorMessage } from '@/commons/lib';
-import { Button, CTAButton, CTAConfirmButton, Toast } from '@/commons/ui';
+import { Button, CTAButton, CTAConfirmButton, DeleteConfirmBottomSheet, Toast } from '@/commons/ui';
 
 import { type Meal, type MealType } from '@/entities/meal';
 
@@ -147,6 +148,30 @@ export function MealEditorScreen({
     );
   }
 
+  function openDeleteConfirm() {
+    overlay.open(({ isOpen, close, unmount }) => {
+      function closeSheet() {
+        close();
+        window.setTimeout(unmount, 200);
+      }
+
+      function confirmDelete() {
+        closeSheet();
+        removeMeal();
+      }
+
+      return (
+        <DeleteConfirmBottomSheet
+          open={isOpen}
+          onClose={closeSheet}
+          onConfirm={confirmDelete}
+          title="식단을 삭제하시겠습니까?"
+          description="삭제된 식단은 복구할 수 없습니다."
+        />
+      );
+    });
+  }
+
   const isMutating = upsertMutation.isPending || deleteMutation.isPending;
 
   return (
@@ -206,7 +231,7 @@ export function MealEditorScreen({
             type="button"
             color="danger"
             variant="subtle"
-            onClick={removeMeal}
+            onClick={openDeleteConfirm}
             disabled={isMutating}
           >
             삭제


### PR DESCRIPTION
## 개요

closes #24

삭제 버튼을 탭했을 때 바로 삭제되지 않고, 확인 BottomSheet를 한 번 더 노출해 실수로 삭제되는 상황을 방지합니다.

## 변경 사항

- `DeleteConfirmBottomSheet` 공통 컴포넌트 신규 생성
  - `overlay-kit`의 `overlay.open()` 패턴과 함께 사용 가능한 controlled BottomSheet
  - `title`, `description`, `confirmLabel`, `cancelLabel`, `isPending` props 지원
- 삭제 확인 BottomSheet 적용 화면
  - 재료 수정 (`FridgeItemEditScreen`) — 재료 삭제
  - 재고 수정 (`FridgeBatchEditScreen`) — 재고 삭제, 기존 `window.confirm` 제거
  - 식단 수정 (`MealEditorScreen`) — 식단 삭제
  - 상품 수정 (`IngredientEditScreen`) — 장보기 상품 삭제

## 동작 방식

```
삭제 버튼 탭
  → overlay.open()으로 DeleteConfirmBottomSheet 노출
  → 취소: BottomSheet 닫기 (삭제 없음)
  → 확인: BottomSheet 닫기 → 삭제 뮤테이션 실행
```

## 테스트 체크리스트

- [ ] 재료 수정 화면에서 삭제 버튼 탭 시 확인 BottomSheet 노출 확인
- [ ] 재고 수정 화면에서 삭제 버튼 탭 시 확인 BottomSheet 노출 확인
- [ ] 식단 수정 화면에서 삭제 버튼 탭 시 확인 BottomSheet 노출 확인
- [ ] 상품 수정 화면에서 삭제 버튼 탭 시 확인 BottomSheet 노출 확인
- [ ] 확인 버튼 탭 시 삭제 실행 확인
- [ ] 취소 버튼 탭 시 삭제 취소 및 BottomSheet 닫힘 확인
- [ ] BottomSheet 외부 영역 탭 시 닫힘 확인