### PR TITLE
feat: 냉장고 재료 추가 시 ml/L 단위 선택 지원

### DIFF
--- a/src/features/fridge/ui/FridgeItemAddScreen.tsx
+++ b/src/features/fridge/ui/FridgeItemAddScreen.tsx
@@ -99,7 +99,7 @@ function createFridgeItemCreateFormSchema(categoryIds: string[]) {
           code: 'custom',
           path: ['quantity'],
           message:
-            value.unit === 'kg'
+            value.unit === 'kg' || value.unit === 'l'
               ? '수량은 소수점 첫째 자리까지 입력할 수 있습니다'
               : '수량은 정수만 입력할 수 있습니다',
         });

--- a/src/features/fridge/ui/FridgeItemAddScreen.tsx
+++ b/src/features/fridge/ui/FridgeItemAddScreen.tsx
@@ -72,7 +72,7 @@ function createFridgeItemCreateFormSchema(categoryIds: string[]) {
         .max(20, ERROR_MSG.RANGE.MAX({ fieldName: '재료명', max: '20자' })),
       brand: z.string().max(30, ERROR_MSG.RANGE.MAX({ fieldName: '브랜드', max: '30자' })),
       quantity: z.number().max(1_000_000, ERROR_MSG.RANGE.MAX({ fieldName: '수량', max: '100만' })),
-      unit: z.enum(['count', 'g', 'kg']),
+      unit: z.enum(['count', 'g', 'kg', 'ml', 'l']),
       is_subdivided: z.boolean(),
       purchased_date: z
         .string()


### PR DESCRIPTION
## 개요

냉장고 재료 추가(`FridgeItemAddScreen`) 화면에서 단위 선택 시 `mL`, `L`이 누락되어 있던 문제를 수정합니다.

장보기(`IngredientForm`), 냉장고 편집(`FridgeItemForm`), 소분(`FridgeItemSubdivideScreen`)은 이미 ml/l를 지원하고 있었으며, 냉장고 재료 추가 화면만 빠져 있었습니다.

## 변경 사항

- `FridgeItemAddScreen` 단위 Select에 `mL`, `L` 옵션 추가
- `isVolumeUnit` import 추가
- 볼륨 단위 전환 시 수량 초기화 조건(`isVolumeUnit` 체크) 누락 수정
- Zod 스키마 `unit` enum에 `ml`, `l` 누락 수정 (제출 시 유효성 검사 오류 방지)

## 영향 범위

- `src/features/fridge/ui/FridgeItemAddScreen.tsx`

## 체크리스트

- [x] `pnpm lint` 통과
- [x] 냉장고 재료 추가 화면에서 mL/L 단위 선택 및 제출 정상 동작 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNvbMGNfkNdzv5jLwP3Mtz)_