### PR TITLE
fix: 비-개 단위 재료의 소진/삭제 판단 로직 수정

### DIFF
--- a/app/api/fridge/batch-usage/route.ts
+++ b/app/api/fridge/batch-usage/route.ts
@@ -20,6 +20,7 @@ export const GET = withAuth(async (req: NextRequest, { supabase }) => {
 
   if (error) return apiResponse.INTERNAL_ERROR();
 
-  const total = (data ?? []).reduce((sum, row) => sum + Number(row.amount ?? 0), 0);
-  return apiResponse.OK(total);
+  const rows = data ?? [];
+  const usedAmount = rows.reduce((sum, row) => sum + Number(row.amount ?? 0), 0);
+  return apiResponse.OK({ usedAmount, hasUsage: rows.length > 0 });
 });

--- a/src/features/fridge/api/queries.ts
+++ b/src/features/fridge/api/queries.ts
@@ -33,12 +33,15 @@ export function useFridgeItemsQuery({
   });
 }
 
-/** 배치별 식단 사용량 합계 조회 */
+/** 배치별 식단 사용량 합계 및 연결 여부 조회 */
 export function useBatchUsedAmountQuery(batchId: string | null) {
   return useQuery({
     queryKey: fridgeItemKeys.batchUsage(batchId ?? ''),
     queryFn: batchId
-      ? () => apiClient.get<number>('/api/fridge/batch-usage', { batchId })
+      ? () =>
+          apiClient.get<{ usedAmount: number; hasUsage: boolean }>('/api/fridge/batch-usage', {
+            batchId,
+          })
       : skipToken,
   });
 }

--- a/src/features/fridge/ui/FridgeBatchEditScreen.tsx
+++ b/src/features/fridge/ui/FridgeBatchEditScreen.tsx
@@ -34,10 +34,11 @@ export function FridgeBatchEditScreen({
   const mutation = useUpdateBatchMutation();
   const deleteMutation = useDeleteBatchMutation();
   const discardMutation = useDiscardBatchMutation();
-  const { data: usedAmount = 0 } = useBatchUsedAmountQuery(batch.id);
+  const { data: batchUsage } = useBatchUsedAmountQuery(batch.id);
+  const usedAmount = batchUsage?.usedAmount ?? 0;
+  const isInMeal = batchUsage?.hasUsage ?? false;
   const formId = `fridge-batch-edit-form-${batch.id}`;
-  const totalQuantity = Number(batch.quantity) + Number(usedAmount);
-  const isInMeal = usedAmount > 0;
+  const totalQuantity = Number(batch.quantity) + usedAmount;
   const quantityUnitLabel = unit === 'count' ? '개' : unit;
 
   function getErrorMessage(error: unknown) {

--- a/src/features/fridge/ui/FridgeItemCard.tsx
+++ b/src/features/fridge/ui/FridgeItemCard.tsx
@@ -70,7 +70,7 @@ export function FridgeItemCard({
     .map((b) => ({ batch: b, days: getDaysUntilExpiry(b.expiry_date!) }))
     .sort((a, b) => a.days - b.days)[0];
 
-  const hasUsage = totalUsedCount > 0;
+  const hasUsage = (item.meal_batch_usages ?? []).length > 0;
 
   function openDeleteConfirm() {
     overlay.open(({ isOpen, close, unmount }) => {


### PR DESCRIPTION
- FridgeItemCard의 hasUsage를 totalUsedCount > 0 대신 meal_batch_usages 레코드 존재 여부로 변경
- batch-usage API가 usedAmount(합계)와 hasUsage(레코드 존재 여부)를 함께 반환하도록 수정
- FridgeBatchEditScreen의 isInMeal을 hasUsage 기반으로 변경