### PR TITLE
fix: 비-개 단위 재료 소진/삭제 판단 로직 수정

### DIFF
--- a/supabase/migrations/066_fix_active_usages_join_for_depleted_batches.sql
+++ b/supabase/migrations/066_fix_active_usages_join_for_depleted_batches.sql
@@ -1,10 +1,6 @@
--- Function: public.get_fridge_items_with_active_batches
--- Source: supabase/migrations/046_add_get_fridge_items_with_active_batches_rpc.sql
--- 역할: 냉장고 목록 조회 시 활성 배치(수량 > 0) 기준으로 재고/사용량을 정합성 있게 반환합니다.
--- 동작:
--- 1. 요청 유저의 household 멤버십과 냉장고 숨김 설정(hide_depleted)을 확인합니다.
--- 2. 수량 > 0, 삭제되지 않은 배치만 활성 배치로 간주해 item을 필터링합니다.
--- 3. 활성 배치와 해당 배치 사용량(meal_batch_usages)만 묶어 JSON 형태로 반환합니다.
+-- 비-개 단위 재료가 소진(depleted) 처리되면 배치 quantity가 0이 되어
+-- active_batches(quantity > 0) 조인에서 meal_batch_usages가 누락되는 문제 수정.
+-- visible_batches(quantity >= 0) 조인으로 변경해 소진된 배치의 사용 기록도 포함한다.
 create or replace function public.get_fridge_items_with_active_batches(
   p_household_id uuid,
   p_search_keyword text default null


### PR DESCRIPTION
## 변경 내용

비-개 단위(g, kg, ml, l) 재료를 식단에서 소진 처리한 후 냉장고에서 삭제할 때, 소진/삭제 다이얼로그 분기가 올바르게 동작하지 않던 문제를 수정합니다.

### 근본 원인

`get_fridge_items_with_active_batches` RPC의 `active_usages` CTE가 `active_batches`(`quantity > 0`)와 조인하고 있었습니다. 비-개 단위 재료가 소진(depleted) 처리되면 배치 `quantity`가 `0`이 돼서 `active_batches`에서 제외되고, 결과적으로 `meal_batch_usages`가 빈 배열로 내려왔습니다.

이 때문에 클라이언트에서 `hasUsage` / `isInMeal`을 판단하는 로직이 비-개 단위에서 항상 `false`로 평가되어 "소진 처리" 대신 "삭제" 다이얼로그가 표시됐습니다.

### 수정 내용

| 파일 | 변경 |
|------|------|
| `get_fridge_items_with_active_batches.sql` (RPC) | `active_usages` CTE 조인을 `active_batches` → `visible_batches`(`quantity >= 0`)로 변경 |
| `supabase/migrations/066_*.sql` | 위 RPC 변경 마이그레이션 |
| `FridgeItemCard.tsx` | `hasUsage`: `totalUsedCount > 0` → `meal_batch_usages.length > 0` |
| `app/api/fridge/batch-usage/route.ts` | `usedAmount`(합계)와 `hasUsage`(레코드 존재 여부)를 함께 반환 |
| `queries.ts` (fridge) | `useBatchUsedAmountQuery` 반환 타입 `number` → `{ usedAmount, hasUsage }` |
| `FridgeBatchEditScreen.tsx` | `isInMeal`을 `hasUsage` 기반으로 분리, `usedAmount`는 수량 계산에만 사용 |

## 영향 범위

- 냉장고 목록 (FridgeItemCard 스와이프 삭제)
- 배치 수정 화면 (FridgeBatchEditScreen 버리기/삭제)
- 만료 재료 화면은 기존 `.some((u) => u.batch_id === batch.id)` 방식으로 이미 올바르게 동작 중

## 확인 시나리오

1. g/kg/ml/l 단위 재료를 냉장고에 추가
2. 식단 편집에서 해당 재료 선택 후 "소진됨" 체크
3. 저장 후 냉장고로 이동
4. 해당 재료 스와이프 → "소진 처리" 다이얼로그가 표시되어야 함 (기존: "삭제" 다이얼로그)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaMXZuH2TQLBsk37oVoGYy)_