### PR TITLE
fix/#8: 냉장고 재료 정보 수정 시 식단 표시가 갱신되지 않는 문제 수정

### DIFF
--- a/src/features/fridge/api/mutations.ts
+++ b/src/features/fridge/api/mutations.ts
@@ -29,7 +29,8 @@ export function useUpdateFridgeItemMutation() {
       apiClient.put<FridgeItem>('/api/fridge', { id, ...updates }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: fridgeItemKeys.all });
-      queryClient.invalidateQueries({ queryKey: mealKeys.fridgeItemsAll });
+      // 재료 이름/정보 변경이 식단 카드 표시에도 반영되도록 식단 관련 캐시 전체 무효화
+      queryClient.invalidateQueries({ queryKey: mealKeys.all });
     },
   });
 }


### PR DESCRIPTION
- useUpdateFridgeItemMutation onSuccess에서 mealKeys.fridgeItemsAll 대신 mealKeys.all을 무효화해 식단 카드 캐시(listByDate)도 함께 갱신