### PR TITLE
fix: 식단 재료 이름 변경 시 식단 표시 싱크 오류 수정

### DIFF
--- a/supabase/migrations/069_fix_dish_ingredients_sync_on_fridge_rename.sql
+++ b/supabase/migrations/069_fix_dish_ingredients_sync_on_fridge_rename.sql
@@ -1,9 +1,15 @@
--- Function: public.update_ingredient_with_fridge
--- Source: supabase/migrations/038_drop_legacy_category_columns_and_use_category_id.sql
--- 역할: 장보기 항목 수정 시 연결 냉장고 재고를 정합성 있게 동기화합니다.
+-- Migration: 069_fix_dish_ingredients_sync_on_fridge_rename
+-- 역할: 장보기에서 재료 이름/브랜드를 수정해 fridge_item이 교체·소프트 삭제될 때,
+--       해당 fridge_item을 참조하는 dish_ingredients도 새 fridge_item으로 동기화한다.
 -- 동작:
--- 1. ingredient 업데이트 후 동일 품목 fridge_item을 재조회/생성합니다.
--- 2. 연결 배치를 목표 fridge_item으로 이동하고 수량/사용량 정합성을 유지합니다.
+-- 1. update_ingredient_with_fridge의 두 소프트 삭제 분기에 dish_ingredients 갱신을 추가한다.
+-- 2. 기존 데이터 정정: 소프트 삭제된 fridge_item을 참조하는 dish_ingredients를
+--    meal_batch_usages를 통해 올바른 fridge_item으로 갱신한다.
+
+/* -------------------------------------------------------------------------------------------------
+ * 1. update_ingredient_with_fridge 함수 수정
+ * -----------------------------------------------------------------------------------------------*/
+
 create or replace function public.update_ingredient_with_fridge(
   p_ingredient_id uuid,
   p_updates jsonb default '{}'::jsonb
@@ -246,3 +252,39 @@ begin
   return v_ingredient;
 end;
 $$;
+
+/* -------------------------------------------------------------------------------------------------
+ * 2. 기존 데이터 정정 — 소프트 삭제된 fridge_item을 참조하는 dish_ingredients 갱신
+ *    - meal_batch_usages를 경유해 해당 meal에서 살아있는 fridge_item으로 매핑한다.
+ *    - 한 meal 내에서 동일 unit+category의 활성 fridge_item이 1개일 때만 갱신 (안전 조건).
+ *    - 멱등: 이미 살아있는 fridge_item을 참조하는 dish_ingredients는 변경 없음.
+ * -----------------------------------------------------------------------------------------------*/
+
+update public.dish_ingredients di
+set fridge_item_id = subq.new_fridge_item_id
+from (
+  select distinct on (di2.id)
+    di2.id,
+    mbu.fridge_item_id as new_fridge_item_id
+  from public.dish_ingredients di2
+  join public.dishes d on d.id = di2.dish_id
+  join public.fridge_items dead_fi on dead_fi.id = di2.fridge_item_id
+    and dead_fi.deleted_at is not null
+  join public.meal_batch_usages mbu on mbu.meal_id = d.meal_id
+  join public.fridge_items live_fi on live_fi.id = mbu.fridge_item_id
+    and live_fi.deleted_at is null
+    and live_fi.unit = dead_fi.unit
+    and live_fi.category_id = dead_fi.category_id
+  where (
+    -- 이 meal에서 dead_fi와 unit+category가 일치하는 활성 fridge_item이 정확히 1개인 경우만 갱신
+    select count(distinct mbu2.fridge_item_id)
+    from public.meal_batch_usages mbu2
+    join public.fridge_items live_fi2 on live_fi2.id = mbu2.fridge_item_id
+      and live_fi2.deleted_at is null
+      and live_fi2.unit = dead_fi.unit
+      and live_fi2.category_id = dead_fi.category_id
+    where mbu2.meal_id = d.meal_id
+  ) = 1
+  order by di2.id
+) subq
+where di.id = subq.id;


### PR DESCRIPTION
## Pull Request Type

- [ ] feat: 기능 구현 (새로운 요구사항 구현, 기존 기능 개선)
- [x] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
  > 성능 개선, 구조 변경, 기능 수정 없을 때
- [ ] style: 포매팅, 린트 (기능 변화 없음)
- [ ] chore: 환경설정, 패키지 관리, 라이브러리 설치 등
- [ ] docs: 문서 작성

## 관련 이슈

closes #8

## 작업 내용

### 1. 장보기 재료명 수정 후 식단 재료가 사라지는 문제 수정

장보기에서 이미 식단에 등록된 재료의 이름을 변경하면(예: "생 말차바" → "생말차바"), 식단 화면에서 해당 재료가 사라지는 현상이 있었다.

`update_ingredient_with_fridge` RPC는 이름 변경 시 새 `fridge_item`을 생성하고 배치를 이동한 뒤 구 `fridge_item`을 soft delete한다. 이때 `meal_batch_usages.fridge_item_id`는 새 ID로 갱신됐지만 `dish_ingredients.fridge_item_id`는 갱신되지 않아 삭제된 row를 참조했고, 식단 조회 JOIN에서 RLS 필터에 의해 NULL이 반환됐다.

두 soft delete 분기 모두에 `dish_ingredients` 동기화를 추가했고, 이미 깨진 기존 데이터도 `meal_batch_usages`를 경유해 정정하는 마이그레이션(069)을 포함했다.

### 2. 냉장고 재료 정보 수정 시 식단 카드에 이름이 반영되지 않는 문제 수정

냉장고 재료 이름을 직접 수정해도 식단 카드에 반영되지 않았다. `useUpdateFridgeItemMutation.onSuccess`에서 `mealKeys.fridgeItemsAll`만 무효화하고 `mealKeys.all`(식단 카드 표시용 `listByDate` 포함)을 무효화하지 않아서였다. `mealKeys.all`로 변경해 모든 식단 관련 캐시를 함께 갱신한다.

### 3. ml/L 단위 지원 및 g/kg 계열 소진·삭제 로직 정합성 수정

ml/L 단위를 냉장고 재료 추가에서 선택할 수 있도록 하고, 관련 유효성 검사와 소수점 오류 메시지를 추가했다. 아울러 만료 재료 스크린·스와이프 등에서 비-개 단위 재료를 소진 대신 삭제로 잘못 처리하던 분기를 수정하고, 소진된 배치의 식단 사용 기록이 냉장고 목록 조회에서 누락되던 문제도 함께 수정했다.

### 4. 같은 품목이라도 브랜드가 다르면 별도 재고로 분리

장보기에서 동일 품목명이지만 브랜드가 다른 재료를 냉장고에 연결할 때 하나의 `fridge_item`으로 합쳐지던 문제를 수정했다. 브랜드를 매칭 키에 포함해 브랜드별로 독립된 재고를 유지하도록 했으며, 식단 재료 선택 화면에서도 브랜드를 함께 표시한다.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BtFx85GpYnSR9CWDnwLp5)_