### PR TITLE
fix: 품목명 수정 시 검색 화면에 기존 값 미리 채우기

### DIFF
--- a/src/apps/stackflow/StackFlow.tsx
+++ b/src/apps/stackflow/StackFlow.tsx
@@ -66,19 +66,21 @@ function IngredientAddActivity({
   const { pop, push } = useActions();
   const { data: brandNames } = useIngredientBrandNamesQuery(params.householdId);
 
-  function openProductNameSearch(_currentName: string, onSelect: (name: string) => void) {
+  function openProductNameSearch(currentName: string, onSelect: (name: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '품목명',
       suggestions: params.suggestions ?? [],
+      currentName,
     });
   }
 
-  function openBrandSearch(_currentBrand: string, onSelect: (brand: string) => void) {
+  function openBrandSearch(currentBrand: string, onSelect: (brand: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '브랜드',
       suggestions: brandNames ?? [],
+      currentName: currentBrand,
     });
   }
 
@@ -105,19 +107,21 @@ function FridgeItemAddActivity({
   const { pop, push } = useActions();
   const { data: brandNames } = useFridgeBrandNamesQuery(params.householdId);
 
-  function openProductNameSearch(_currentName: string, onSelect: (name: string) => void) {
+  function openProductNameSearch(currentName: string, onSelect: (name: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '재료명',
       suggestions: params.suggestions ?? [],
+      currentName,
     });
   }
 
-  function openBrandSearch(_currentBrand: string, onSelect: (brand: string) => void) {
+  function openBrandSearch(currentBrand: string, onSelect: (brand: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '브랜드',
       suggestions: brandNames ?? [],
+      currentName: currentBrand,
     });
   }
 
@@ -142,19 +146,21 @@ function FridgeItemEditActivity({
   const { pop, push } = useActions();
   const { data: brandNames } = useFridgeBrandNamesQuery(params.item.household_id);
 
-  function openProductNameSearch(_currentName: string, onSelect: (name: string) => void) {
+  function openProductNameSearch(currentName: string, onSelect: (name: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '재료명',
       suggestions: params.suggestions ?? [],
+      currentName,
     });
   }
 
-  function openBrandSearch(_currentBrand: string, onSelect: (brand: string) => void) {
+  function openBrandSearch(currentBrand: string, onSelect: (brand: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '브랜드',
       suggestions: brandNames ?? [],
+      currentName: currentBrand,
     });
   }
 
@@ -255,19 +261,21 @@ function IngredientEditActivity({
   const { pop, push } = useActions();
   const { data: brandNames } = useIngredientBrandNamesQuery(params.householdId);
 
-  function openProductNameSearch(_currentName: string, onSelect: (name: string) => void) {
+  function openProductNameSearch(currentName: string, onSelect: (name: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '품목명',
       suggestions: params.suggestions ?? [],
+      currentName,
     });
   }
 
-  function openBrandSearch(_currentBrand: string, onSelect: (brand: string) => void) {
+  function openBrandSearch(currentBrand: string, onSelect: (brand: string) => void) {
     setPendingProductNameCallback(onSelect);
     push('ProductNameSearchActivity', {
       fieldLabel: '브랜드',
       suggestions: brandNames ?? [],
+      currentName: currentBrand,
     });
   }
 
@@ -447,6 +455,7 @@ function ProductNameSearchActivity({
     fieldLabel?: string;
     suggestions?: string[];
     depletedNames?: string[];
+    currentName?: string;
   };
 }) {
   const { pop } = useActions();
@@ -468,6 +477,7 @@ function ProductNameSearchActivity({
       fieldLabel={params.fieldLabel}
       suggestions={params.suggestions}
       depletedNames={params.depletedNames}
+      defaultQuery={params.currentName}
     />
   );
 }

--- a/src/features/ingredient/ui/ProductNameSearchScreen.tsx
+++ b/src/features/ingredient/ui/ProductNameSearchScreen.tsx
@@ -19,6 +19,8 @@ interface ProductNameSearchScreenProps {
   suggestions?: string[];
   /** 소진 상태인 항목 이름 목록 — 해당 항목에 소진 뱃지를 표시한다 */
   depletedNames?: string[];
+  /** 검색창 진입 시 미리 채워둘 기존 값 (수정 진입 시 현재 품목명 등) */
+  defaultQuery?: string;
 }
 
 /** 상품명 검색 전용 Screen — onClose/onSelectName을 Activity에서 주입받아 동작한다 */
@@ -28,14 +30,16 @@ export function ProductNameSearchScreen({
   fieldLabel = '상품명',
   suggestions = [],
   depletedNames = [],
+  defaultQuery = '',
 }: ProductNameSearchScreenProps) {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState(defaultQuery);
   const inputRef = useRef<HTMLInputElement>(null);
   const depletedSet = new Set(depletedNames);
 
-  useEffect(function focusOnMount() {
+  useEffect(function focusAndSelectOnMount() {
     const timer = window.setTimeout(() => {
       inputRef.current?.focus();
+      inputRef.current?.select();
     }, 100);
     return () => window.clearTimeout(timer);
   }, []);


### PR DESCRIPTION
- 품목명/브랜드 수정 진입 시 현재 값을 ProductNameSearchActivity에 currentName으로 전달
- ProductNameSearchScreen이 defaultQuery로 초기값을 채우고 포커스 시 전체 선택하도록 변경