### PR TITLE
fix: 단위 표기 대소문자 정책 정정

### DIFF
--- a/src/entities/ingredient/model/unit.ts
+++ b/src/entities/ingredient/model/unit.ts
@@ -78,8 +78,8 @@ export function convertIngredientAmount(value: number, from: IngredientUnit, to:
 export function formatWeightAuto(value: number, unit: IngredientUnit) {
   const grams = toGrams(value, unit);
   if (grams === null) return String(value);
-  if (grams >= 1000) return `${(grams / 1000).toFixed(1)}Kg`;
-  return `${Math.round(grams)}G`;
+  if (grams >= 1000) return `${(grams / 1000).toFixed(1)}kg`;
+  return `${Math.round(grams)}g`;
 }
 
 /**
@@ -89,7 +89,7 @@ export function formatVolumeAuto(value: number, unit: IngredientUnit) {
   const ml = toMilliliters(value, unit);
   if (ml === null) return String(value);
   if (ml >= 1000) return `${(ml / 1000).toFixed(1)}L`;
-  return `${Math.round(ml)}mL`;
+  return `${Math.round(ml)}ml`;
 }
 
 /**
@@ -103,9 +103,9 @@ export function formatIngredientAmount(value: number, unit: IngredientUnit, dyna
   }
   const UNIT_DISPLAY: Record<IngredientUnit, string> = {
     count: '개',
-    g: 'G',
-    kg: 'Kg',
-    ml: 'mL',
+    g: 'g',
+    kg: 'kg',
+    ml: 'ml',
     l: 'L',
   };
   return `${value}${UNIT_DISPLAY[unit]}`;

--- a/src/features/fridge/ui/FridgeItemAddScreen.tsx
+++ b/src/features/fridge/ui/FridgeItemAddScreen.tsx
@@ -360,9 +360,9 @@ export function FridgeItemAddScreen({
                       </Form.Control>
                       <Select.Content>
                         <Select.Item value="count">개</Select.Item>
-                        <Select.Item value="g">G</Select.Item>
-                        <Select.Item value="kg">Kg</Select.Item>
-                        <Select.Item value="ml">mL</Select.Item>
+                        <Select.Item value="g">g</Select.Item>
+                        <Select.Item value="kg">kg</Select.Item>
+                        <Select.Item value="ml">ml</Select.Item>
                         <Select.Item value="l">L</Select.Item>
                       </Select.Content>
                     </Select>

--- a/src/features/fridge/ui/FridgeItemForm.tsx
+++ b/src/features/fridge/ui/FridgeItemForm.tsx
@@ -207,9 +207,9 @@ export function FridgeItemForm({
               </Form.Control>
               <Select.Content>
                 <Select.Item value="count">개</Select.Item>
-                <Select.Item value="g">G</Select.Item>
-                <Select.Item value="kg">Kg</Select.Item>
-                <Select.Item value="ml">mL</Select.Item>
+                <Select.Item value="g">g</Select.Item>
+                <Select.Item value="kg">kg</Select.Item>
+                <Select.Item value="ml">ml</Select.Item>
                 <Select.Item value="l">L</Select.Item>
               </Select.Content>
             </Select>

--- a/src/features/fridge/ui/FridgeItemSubdivideScreen.tsx
+++ b/src/features/fridge/ui/FridgeItemSubdivideScreen.tsx
@@ -24,9 +24,9 @@ interface FridgeItemSubdivideScreenProps {
 
 const UNIT_LABEL: Record<FridgeItemUnit, string> = {
   count: '개',
-  g: 'G',
-  kg: 'Kg',
-  ml: 'mL',
+  g: 'g',
+  kg: 'kg',
+  ml: 'ml',
   l: 'L',
 };
 

--- a/src/features/ingredient/ui/IngredientForm.tsx
+++ b/src/features/ingredient/ui/IngredientForm.tsx
@@ -335,9 +335,9 @@ export function IngredientForm({
                   </Form.Control>
                   <Select.Content>
                     <Select.Item value="count">개</Select.Item>
-                    <Select.Item value="g">G</Select.Item>
-                    <Select.Item value="kg">Kg</Select.Item>
-                    <Select.Item value="ml">mL</Select.Item>
+                    <Select.Item value="g">g</Select.Item>
+                    <Select.Item value="kg">kg</Select.Item>
+                    <Select.Item value="ml">ml</Select.Item>
                     <Select.Item value="l">L</Select.Item>
                   </Select.Content>
                 </Select>

--- a/src/features/meal/lib/unit.ts
+++ b/src/features/meal/lib/unit.ts
@@ -7,9 +7,9 @@ import { normalizeAmount } from '../model/amount';
  */
 function resolveIngredientUnitLabel(unit: IngredientUnit | undefined) {
   if (unit === 'count') return '개';
-  if (unit === 'g') return 'G';
-  if (unit === 'kg') return 'Kg';
-  if (unit === 'ml') return 'mL';
+  if (unit === 'g') return 'g';
+  if (unit === 'kg') return 'kg';
+  if (unit === 'ml') return 'ml';
   if (unit === 'l') return 'L';
   return '단위';
 }


### PR DESCRIPTION
- g, kg, ml은 소문자로, l(리터)만 대문자(L)로 표시하도록 변경
- entities/ingredient 단위 포맷터, features/meal 단위 라벨, 냉장고/재료 단위 Select 옵션에 반영