### PR TITLE
fix: 식단 미사용 재고/장보기 항목의 단위 수정 제한 완화

### DIFF
--- a/app/api/ingredients/route.ts
+++ b/app/api/ingredients/route.ts
@@ -46,6 +46,41 @@ export const GET = withAuth(async (req: NextRequest, { supabase }) => {
 
   if (error) return apiResponse.INTERNAL_ERROR();
 
+  const ingredients = (data ?? []) as Ingredient[];
+
+  const fridgeItemIds = [
+    ...new Set(ingredients.map((i) => i.linked_fridge_item_id).filter((id): id is string => !!id)),
+  ];
+  const fridgeBatchIds = [
+    ...new Set(ingredients.map((i) => i.linked_fridge_batch_id).filter((id): id is string => !!id)),
+  ];
+
+  const [dishIngredientsResult, mealBatchUsagesResult] = await Promise.all([
+    fridgeItemIds.length
+      ? supabase
+          .from('dish_ingredients')
+          .select('fridge_item_id')
+          .in('fridge_item_id', fridgeItemIds)
+      : Promise.resolve({ data: [] as { fridge_item_id: string }[] }),
+    fridgeBatchIds.length
+      ? supabase.from('meal_batch_usages').select('batch_id').in('batch_id', fridgeBatchIds)
+      : Promise.resolve({ data: [] as { batch_id: string }[] }),
+  ]);
+
+  const usedFridgeItemIds = new Set(
+    (dishIngredientsResult.data ?? []).map((row) => row.fridge_item_id),
+  );
+  const usedFridgeBatchIds = new Set((mealBatchUsagesResult.data ?? []).map((row) => row.batch_id));
+
+  const contents = ingredients.map((ingredient) => ({
+    ...ingredient,
+    has_meal_usage:
+      (!!ingredient.linked_fridge_item_id &&
+        usedFridgeItemIds.has(ingredient.linked_fridge_item_id)) ||
+      (!!ingredient.linked_fridge_batch_id &&
+        usedFridgeBatchIds.has(ingredient.linked_fridge_batch_id)),
+  }));
+
   const totalElements = count ?? 0;
   const totalPages = Math.ceil(totalElements / pageSize);
 
@@ -54,14 +89,14 @@ export const GET = withAuth(async (req: NextRequest, { supabase }) => {
     pageSize,
     totalElements,
     totalPages,
-    numberOfElements: data?.length ?? 0,
-    empty: (data?.length ?? 0) === 0,
+    numberOfElements: contents.length,
+    empty: contents.length === 0,
     first: page === 1,
     last: page >= totalPages,
   };
 
   const result: Page<Ingredient[]> = {
-    contents: (data ?? []) as Ingredient[],
+    contents,
     pageInfo,
   };
 

--- a/src/entities/ingredient/model/types.ts
+++ b/src/entities/ingredient/model/types.ts
@@ -31,4 +31,10 @@ export interface Ingredient {
   deleted_at: string | null;
   created_at: string;
   updated_at: string;
+  /**
+   * 연결된 냉장고 재료/배치의 식단 사용 이력 유무.
+   * linked_fridge_item_id 기준 dish_ingredients 존재 여부 또는
+   * linked_fridge_batch_id 기준 meal_batch_usages 존재 여부로 계산된다.
+   */
+  has_meal_usage?: boolean;
 }

--- a/src/features/fridge/ui/FridgeItemEditScreen.tsx
+++ b/src/features/fridge/ui/FridgeItemEditScreen.tsx
@@ -35,8 +35,10 @@ export function FridgeItemEditScreen({
   const deleteMutation = useDeleteFridgeItemMutation();
   const discardMutation = useDiscardFridgeItemMutation();
   const formId = `fridge-item-edit-form-${item.id}`;
-  const disableUnitSelect = item.fridge_item_batches.length > 0;
-  const isInMeal = (item.meal_batch_usages?.length ?? 0) > 0;
+  // 식단 사용 이력은 dish_ingredients 기준(has_meal_usage)이 완전한 출처다.
+  // g/kg 'used'처럼 meal_batch_usages 행이 없는 사용도 단위 잠금 대상에 포함한다.
+  const isInMeal = item.has_meal_usage === true || (item.meal_batch_usages?.length ?? 0) > 0;
+  const disableUnitSelect = isInMeal;
 
   function getErrorMessage(error: unknown) {
     if (error instanceof Error) return error.message;

--- a/src/features/ingredient/ui/IngredientEditScreen.tsx
+++ b/src/features/ingredient/ui/IngredientEditScreen.tsx
@@ -119,7 +119,7 @@ export function IngredientEditScreen({
           onSubmit={handleSubmit}
           isSubmitting={updateMutation.isPending}
           isDeleting={deleteMutation.isPending}
-          disableUnitSelect
+          disableUnitSelect={ingredient.has_meal_usage === true}
           onOpenProductNameSearch={onOpenProductNameSearch}
           onOpenBrandSearch={onOpenBrandSearch}
         />


### PR DESCRIPTION
- IngredientEditScreen: 상품 수정에서 무조건 단위를 잠그던 로직을 has_meal_usage 기준으로 변경
- FridgeItemEditScreen: 배치 존재 여부(fridge_item_batches.length)가 아닌 실제 식단 사용 여부(has_meal_usage/meal_batch_usages)로 단위 잠금 조건 수정
- Ingredient 타입에 has_meal_usage 필드 추가, /api/ingredients GET에서 연결된 냉장고 재료/배치의 식단 사용 이력을 계산해 함께 반환