### PR TITLE
fix: 영수증 분석 화면 뒤로가기 시 분석중 상태 고착 수정

### DIFF
--- a/src/features/ingredient/ui/PromptIngredientAddScreen.tsx
+++ b/src/features/ingredient/ui/PromptIngredientAddScreen.tsx
@@ -56,6 +56,7 @@ export function PromptIngredientAddScreen({
   const [payload, setPayload] = useState<ImagePayload | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
   const [stepIndex, setStepIndex] = useState(0);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(
     function revokePreviewOnChange() {
@@ -64,6 +65,12 @@ export function PromptIngredientAddScreen({
     },
     [preview],
   );
+
+  useEffect(function clearResetTimerOnUnmount() {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
 
   useEffect(
     function cycleAnalyzingSteps() {
@@ -102,6 +109,12 @@ export function PromptIngredientAddScreen({
       });
       setItems(items);
       onParsed(items);
+      resetTimerRef.current = setTimeout(() => {
+        setStatus('idle');
+        setPreview(null);
+        setPayload(null);
+        setErrorMessage('');
+      }, 2000);
     } catch (err) {
       // 사용자에겐 친화적 message를, 콘솔엔 실제 원인(cause)을 남긴다
       console.error('[receipt-parse]', err instanceof Error ? (err.cause ?? err) : err);


### PR DESCRIPTION
- 추가품목 화면으로 전환된 뒤 2초 후 영수증 업로드 화면의 로컬 상태를 idle로 초기화
- 뒤로가기로 돌아왔을 때 분석중 화면에 멈춰 보이는 문제 해결