### PR TITLE
feat: 카테고리별 기본 유효기간 설정 기능 추가

### DIFF
--- a/app/api/fridge/category-expiry-defaults/route.ts
+++ b/app/api/fridge/category-expiry-defaults/route.ts
@@ -1,0 +1,82 @@
+import { type NextRequest } from 'next/server';
+
+import { withAuth } from '@/apps/route';
+
+import { resolveDomainError } from '@/commons/lib';
+import { apiResponse } from '@/commons/lib/http/apiResponse';
+
+/** GET /api/fridge/category-expiry-defaults?householdId= — 가구 카테고리별 기본 유효기간 목록 조회 */
+export const GET = withAuth(async (req: NextRequest, { supabase }) => {
+  const householdId = req.nextUrl.searchParams.get('householdId');
+
+  if (!householdId) {
+    return apiResponse.BAD_REQUEST('CMN_002', 'householdId가 필요합니다.');
+  }
+
+  const { data, error } = await supabase
+    .from('fridge_category_expiry_defaults')
+    .select('category_id, default_expiry_days')
+    .eq('household_id', householdId);
+
+  if (error) {
+    const domainError = resolveDomainError(error);
+    if (domainError) return apiResponse.CONFLICT(domainError.code, domainError.message);
+    return apiResponse.INTERNAL_ERROR();
+  }
+
+  return apiResponse.OK(data ?? []);
+});
+
+/**
+ * PUT /api/fridge/category-expiry-defaults — 카테고리별 기본 유효기간 설정 저장
+ * body: { householdId, categoryId, days }
+ * days가 null이면 해당 카테고리 설정을 제거(미설정으로 되돌림)한다.
+ */
+export const PUT = withAuth(async (req: NextRequest, { supabase }) => {
+  const body = await req.json();
+  const householdId = body.householdId as string | undefined;
+  const categoryId = body.categoryId as string | undefined;
+  const days = body.days as number | null | undefined;
+
+  if (!householdId || !categoryId) {
+    return apiResponse.BAD_REQUEST('CMN_002', 'householdId와 categoryId가 필요합니다.');
+  }
+
+  if (days === null || days === undefined) {
+    const { error } = await supabase
+      .from('fridge_category_expiry_defaults')
+      .delete()
+      .eq('household_id', householdId)
+      .eq('category_id', categoryId);
+
+    if (error) {
+      const domainError = resolveDomainError(error);
+      if (domainError) return apiResponse.CONFLICT(domainError.code, domainError.message);
+      return apiResponse.INTERNAL_ERROR();
+    }
+
+    return apiResponse.NO_CONTENT();
+  }
+
+  if (!Number.isInteger(days) || days < 1 || days > 180) {
+    return apiResponse.BAD_REQUEST('CMN_002', '기본 유효기간은 1~180일 사이여야 합니다.');
+  }
+
+  const { error } = await supabase.from('fridge_category_expiry_defaults').upsert(
+    {
+      household_id: householdId,
+      category_id: categoryId,
+      default_expiry_days: days,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'household_id,category_id' },
+  );
+
+  if (error) {
+    const domainError = resolveDomainError(error);
+    if (domainError) return apiResponse.CONFLICT(domainError.code, domainError.message);
+    return apiResponse.INTERNAL_ERROR();
+  }
+
+  return apiResponse.NO_CONTENT();
+});

--- a/src/commons/lib/error/errorMessage.ts
+++ b/src/commons/lib/error/errorMessage.ts
@@ -47,6 +47,10 @@ export const ERROR_MSG = {
     MISMATCH: ({ fieldName }: { fieldName: string }) =>
       `${josa(fieldName, '이/가')} 일치하지 않습니다.` as const,
   },
+  DATE: {
+    ON_OR_AFTER: ({ fieldName, baseName }: { fieldName: string; baseName: string }) =>
+      `${josa(fieldName, '은/는')} ${baseName} 이후여야 합니다.` as const,
+  },
   RANGE: {
     BETWEEN: ({ fieldName, min, max }: RangeProps) =>
       `${josa(fieldName, '은/는')} ${min}부터 ${max}사이의 값을 입력해야 합니다.` as const,

--- a/src/commons/model/types/database.ts
+++ b/src/commons/model/types/database.ts
@@ -585,6 +585,33 @@ export interface Database {
         };
         Relationships: [];
       };
+      fridge_category_expiry_defaults: {
+        Row: {
+          id: string;
+          household_id: string;
+          category_id: string;
+          default_expiry_days: number;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          household_id: string;
+          category_id: string;
+          default_expiry_days: number;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          household_id?: string;
+          category_id?: string;
+          default_expiry_days?: number;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       [_ in never]: never;

--- a/src/entities/fridge-item/api/queryKey.ts
+++ b/src/entities/fridge-item/api/queryKey.ts
@@ -6,4 +6,6 @@ export const fridgeItemKeys = {
   batchUsage: (batchId: string) => [...fridgeItemKeys.all, 'batch-usage', batchId] as const,
   preferences: (userId: string) => [...fridgeItemKeys.all, 'preferences', userId] as const,
   brands: (householdId: string) => [...fridgeItemKeys.all, 'brands', householdId] as const,
+  categoryExpiryDefaults: (householdId: string) =>
+    [...fridgeItemKeys.all, 'category-expiry-defaults', householdId] as const,
 };

--- a/src/features/fridge/api/mutations.ts
+++ b/src/features/fridge/api/mutations.ts
@@ -138,6 +138,31 @@ export function useSubdivideFridgeItemMutation() {
   });
 }
 
+interface UpsertCategoryExpiryDefaultInput {
+  householdId: string;
+  categoryId: string;
+  /** null이면 해당 카테고리 설정을 제거(미설정) */
+  days: number | null;
+}
+
+/** 카테고리별 기본 유효기간 설정 저장 (days=null이면 제거) */
+export function useUpsertCategoryExpiryDefaultMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: UpsertCategoryExpiryDefaultInput) =>
+      apiClient.put('/api/fridge/category-expiry-defaults', input),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: fridgeItemKeys.categoryExpiryDefaults(variables.householdId),
+      });
+    },
+    onError: (error) => {
+      Toast.error(error.message);
+    },
+  });
+}
+
 interface UpsertFridgePreferencesInput {
   userId: string;
   values: { hide_depleted_fridge_items: boolean };

--- a/src/features/fridge/api/mutations.ts
+++ b/src/features/fridge/api/mutations.ts
@@ -6,6 +6,8 @@ import { Toast } from '@/commons/ui';
 import { fridgeItemKeys, type FridgeItem, type FridgeItemBatch } from '@/entities/fridge-item';
 import { mealKeys } from '@/entities/meal';
 
+import { type CategoryExpiryDefaultRow } from './queries';
+
 /** 냉장고 아이템 + 첫 배치 동시 추가 */
 export function useAddFridgeItemMutation() {
   const queryClient = useQueryClient();
@@ -145,20 +147,39 @@ interface UpsertCategoryExpiryDefaultInput {
   days: number | null;
 }
 
-/** 카테고리별 기본 유효기간 설정 저장 (days=null이면 제거) */
+/** 카테고리별 기본 유효기간 설정 저장 (days=null이면 제거) — 낙관적 업데이트 적용 */
 export function useUpsertCategoryExpiryDefaultMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (input: UpsertCategoryExpiryDefaultInput) =>
       apiClient.put('/api/fridge/category-expiry-defaults', input),
-    onSuccess: (_data, variables) => {
+    onMutate: async (variables) => {
+      const queryKey = fridgeItemKeys.categoryExpiryDefaults(variables.householdId);
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousRows = queryClient.getQueryData<CategoryExpiryDefaultRow[]>(queryKey);
+      queryClient.setQueryData<CategoryExpiryDefaultRow[]>(queryKey, (rows = []) => {
+        const withoutCategory = rows.filter((row) => row.category_id !== variables.categoryId);
+        if (variables.days === null) return withoutCategory;
+        return [
+          ...withoutCategory,
+          { category_id: variables.categoryId, default_expiry_days: variables.days },
+        ];
+      });
+
+      return { queryKey, previousRows };
+    },
+    onError: (error, _variables, context) => {
+      if (context) {
+        queryClient.setQueryData(context.queryKey, context.previousRows);
+      }
+      Toast.error(error.message);
+    },
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({
         queryKey: fridgeItemKeys.categoryExpiryDefaults(variables.householdId),
       });
-    },
-    onError: (error) => {
-      Toast.error(error.message);
     },
   });
 }

--- a/src/features/fridge/api/queries.ts
+++ b/src/features/fridge/api/queries.ts
@@ -9,6 +9,14 @@ interface FridgePreferences {
   hide_depleted_fridge_items: boolean;
 }
 
+interface CategoryExpiryDefaultRow {
+  category_id: string;
+  default_expiry_days: number;
+}
+
+/** categoryId → 기본 유효기간(일수) 맵 */
+export type CategoryExpiryDefaultsMap = Record<string, number>;
+
 /** 냉장고 재고 전체 조회 (배치 포함) */
 export function useFridgeItemsQuery({
   householdId,
@@ -53,6 +61,21 @@ export function useFridgePreferencesQuery(userId: string | null) {
     queryFn: userId
       ? () => apiClient.get<FridgePreferences | null>('/api/fridge/preferences')
       : skipToken,
+  });
+}
+
+/** 가구 카테고리별 기본 유효기간 조회 (categoryId → 일수 맵으로 변환) */
+export function useCategoryExpiryDefaultsQuery(householdId: string | null) {
+  return useQuery({
+    queryKey: fridgeItemKeys.categoryExpiryDefaults(householdId ?? ''),
+    queryFn: householdId
+      ? () =>
+          apiClient.get<CategoryExpiryDefaultRow[]>('/api/fridge/category-expiry-defaults', {
+            householdId,
+          })
+      : skipToken,
+    select: (rows): CategoryExpiryDefaultsMap =>
+      Object.fromEntries(rows.map((row) => [row.category_id, row.default_expiry_days])),
   });
 }
 

--- a/src/features/fridge/api/queries.ts
+++ b/src/features/fridge/api/queries.ts
@@ -9,13 +9,16 @@ interface FridgePreferences {
   hide_depleted_fridge_items: boolean;
 }
 
-interface CategoryExpiryDefaultRow {
+export interface CategoryExpiryDefaultRow {
   category_id: string;
   default_expiry_days: number;
 }
 
 /** categoryId → 기본 유효기간(일수) 맵 */
 export type CategoryExpiryDefaultsMap = Record<string, number>;
+
+// 가구 카테고리 기본 유효기간은 자주 바뀌지 않으므로 카테고리 목록과 동일하게 6시간 캐시한다.
+const CATEGORY_EXPIRY_DEFAULTS_STALE_TIME = 1000 * 60 * 60 * 6;
 
 /** 냉장고 재고 전체 조회 (배치 포함) */
 export function useFridgeItemsQuery({
@@ -68,6 +71,7 @@ export function useFridgePreferencesQuery(userId: string | null) {
 export function useCategoryExpiryDefaultsQuery(householdId: string | null) {
   return useQuery({
     queryKey: fridgeItemKeys.categoryExpiryDefaults(householdId ?? ''),
+    staleTime: CATEGORY_EXPIRY_DEFAULTS_STALE_TIME,
     queryFn: householdId
       ? () =>
           apiClient.get<CategoryExpiryDefaultRow[]>('/api/fridge/category-expiry-defaults', {

--- a/src/features/fridge/index.ts
+++ b/src/features/fridge/index.ts
@@ -2,7 +2,9 @@ export {
   useBatchUsedAmountQuery,
   useFridgeItemsQuery,
   useFridgePreferencesQuery,
+  useCategoryExpiryDefaultsQuery,
   useFridgeBrandNamesQuery,
+  type CategoryExpiryDefaultsMap,
 } from './api/queries';
 export {
   useAddFridgeItemMutation,
@@ -12,6 +14,7 @@ export {
   useUpdateBatchMutation,
   useDeleteBatchMutation,
   useUpsertFridgePreferencesMutation,
+  useUpsertCategoryExpiryDefaultMutation,
   useSubdivideFridgeItemMutation,
 } from './api/mutations';
 export { ExpiryBadge } from './ui/ExpiryBadge';

--- a/src/features/fridge/lib/expiry.ts
+++ b/src/features/fridge/lib/expiry.ts
@@ -1,6 +1,20 @@
-import { differenceInDays, startOfDay } from 'date-fns';
+import { addDays, differenceInDays, format, parseISO, startOfDay } from 'date-fns';
 
 import { type FridgeItemBatch } from '@/entities/fridge-item';
+
+/**
+ * @description 구매일(YYYY-MM-DD)과 카테고리 기본 유효기간(일수)로 유통기한(YYYY-MM-DD)을 계산한다.
+ * 구매일이 없거나 일수가 없으면(미설정) null을 반환한다. 결과가 과거 날짜여도 그대로 반환한다.
+ */
+export function computeExpiryDate(
+  purchasedDate: string,
+  days: number | null | undefined,
+): string | null {
+  if (!purchasedDate || days === null || days === undefined) return null;
+  const parsed = parseISO(purchasedDate);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return format(addDays(parsed, days), 'yyyy-MM-dd');
+}
 
 /** 유통기한까지 남은 일수 계산 (음수 = 만료됨) */
 export function getDaysUntilExpiry(expiryDate: string): number {

--- a/src/features/fridge/ui/CategoryExpiryDefaultsSection.tsx
+++ b/src/features/fridge/ui/CategoryExpiryDefaultsSection.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { ChevronRight } from 'lucide-react';
+
+import { Card, SingleSelectBottomSheet, type SingleSelectBottomSheetItem } from '@/commons/ui';
+
+import { useIngredientCategoriesQuery } from '@/entities/ingredient-category';
+
+import { useUpsertCategoryExpiryDefaultMutation } from '../api/mutations';
+import { useCategoryExpiryDefaultsQuery } from '../api/queries';
+
+const NONE_VALUE = 'none';
+const MIN_DAYS = 1;
+const MAX_DAYS = 180;
+
+const DAY_ITEMS: SingleSelectBottomSheetItem[] = [
+  { value: NONE_VALUE, label: '설정 안 함' },
+  ...Array.from({ length: MAX_DAYS - MIN_DAYS + 1 }, (_, index) => {
+    const day = MIN_DAYS + index;
+    return { value: String(day), label: `${day}일` };
+  }),
+];
+
+interface CategoryExpiryDefaultsSectionProps {
+  householdId: string;
+}
+
+/** 카테고리별 기본 유효기간 설정 섹션 (가구 공유) */
+export function CategoryExpiryDefaultsSection({ householdId }: CategoryExpiryDefaultsSectionProps) {
+  const { data: categories = [] } = useIngredientCategoriesQuery(householdId);
+  const { data: defaults = {} } = useCategoryExpiryDefaultsQuery(householdId);
+  const upsertMutation = useUpsertCategoryExpiryDefaultMutation();
+
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+  const [sheetValue, setSheetValue] = useState<string>(NONE_VALUE);
+
+  const editingCategory = useMemo(
+    () => categories.find((category) => category.id === editingCategoryId) ?? null,
+    [categories, editingCategoryId],
+  );
+
+  function openEditor(categoryId: string) {
+    const currentDays = defaults[categoryId];
+    setSheetValue(currentDays !== undefined ? String(currentDays) : NONE_VALUE);
+    setEditingCategoryId(categoryId);
+  }
+
+  function closeEditor() {
+    setEditingCategoryId(null);
+  }
+
+  function applyValue(nextValue: string) {
+    if (!editingCategoryId) return;
+    const days = nextValue === NONE_VALUE ? null : Number(nextValue);
+    upsertMutation.mutate({ householdId, categoryId: editingCategoryId, days });
+  }
+
+  return (
+    <section className="space-y-2">
+      <div className="px-1">
+        <p className="text-sm font-medium text-gray-900">카테고리별 기본 유효기간</p>
+        <p className="text-xs text-gray-500">
+          새 재고 등록 시 구매일 기준으로 유통기한이 자동 입력됩니다
+        </p>
+      </div>
+      <Card>
+        <Card.Content className="p-0">
+          <ul className="divide-y divide-gray-100">
+            {categories.map((category) => {
+              const days = defaults[category.id];
+              return (
+                <li key={category.id}>
+                  <button
+                    type="button"
+                    onClick={() => openEditor(category.id)}
+                    className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
+                  >
+                    <span className="inline-flex items-center gap-2 text-sm text-gray-900">
+                      {category.emoji ? (
+                        <span className="font-tossface" aria-hidden>
+                          {category.emoji}
+                        </span>
+                      ) : null}
+                      {category.label}
+                    </span>
+                    <span className="inline-flex items-center gap-1 text-sm text-gray-500">
+                      {days !== undefined ? `${days}일` : '설정 안 함'}
+                      <ChevronRight className="size-4 text-gray-400" />
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </Card.Content>
+      </Card>
+
+      <SingleSelectBottomSheet
+        open={editingCategoryId !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) closeEditor();
+        }}
+        value={sheetValue}
+        onValueChange={applyValue}
+        items={DAY_ITEMS}
+        heading={editingCategory ? `${editingCategory.label} 기본 유효기간` : '기본 유효기간'}
+        confirmLabel="확인"
+      />
+    </section>
+  );
+}

--- a/src/features/fridge/ui/FridgeFilterSettingsScreen.tsx
+++ b/src/features/fridge/ui/FridgeFilterSettingsScreen.tsx
@@ -6,8 +6,12 @@ import { ChevronLeft } from 'lucide-react';
 import { useUserSuspenseQuery } from '@/commons/api/auth/queries';
 import { Button, Card, Switch } from '@/commons/ui';
 
+import { useProfileQuery } from '@/entities/profile';
+
 import { useFridgePreferencesQuery } from '../api/queries';
 import { useUpsertFridgePreferencesMutation } from '../api/mutations';
+
+import { CategoryExpiryDefaultsSection } from './CategoryExpiryDefaultsSection';
 
 interface FridgeFilterSettingsScreenProps {
   onClose: () => void;
@@ -16,8 +20,10 @@ interface FridgeFilterSettingsScreenProps {
 /** 냉장고 필터 설정 화면 */
 export function FridgeFilterSettingsScreen({ onClose }: FridgeFilterSettingsScreenProps) {
   const { data: user } = useUserSuspenseQuery();
+  const { data: profile } = useProfileQuery(user.id);
   const { data: preferences } = useFridgePreferencesQuery(user.id);
   const upsertFridgePreferencesMutation = useUpsertFridgePreferencesMutation();
+  const householdId = profile?.household_id ?? null;
 
   const hideDepletedItems = preferences?.hide_depleted_fridge_items ?? false;
 
@@ -66,6 +72,8 @@ export function FridgeFilterSettingsScreen({ onClose }: FridgeFilterSettingsScre
             </div>
           </Card.Content>
         </Card>
+
+        {householdId ? <CategoryExpiryDefaultsSection householdId={householdId} /> : null}
       </div>
     </AppScreen>
   );

--- a/src/features/fridge/ui/FridgeItemAddScreen.tsx
+++ b/src/features/fridge/ui/FridgeItemAddScreen.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import { AppScreen } from '@stackflow/plugin-basic-ui';
 import { useForm } from '@tanstack/react-form';
 import { format } from 'date-fns';
 import { ChevronRight } from 'lucide-react';
+import { useConditionalEffect } from 'react-simplikit';
 import { z } from 'zod';
 
 import { cn, ERROR_MSG } from '@/commons/lib';
@@ -38,7 +39,9 @@ import {
   useIngredientCategoriesQuery,
 } from '@/entities/ingredient-category';
 
+import { useCategoryExpiryDefaultsQuery } from '../api/queries';
 import { useAddFridgeItemMutation } from '../api/mutations';
+import { computeExpiryDate } from '../lib/expiry';
 
 interface FridgeItemAddScreenProps {
   onClose: () => void;
@@ -84,6 +87,14 @@ function createFridgeItemCreateFormSchema(categoryIds: string[]) {
       memo: z.string().max(300, ERROR_MSG.RANGE.MAX({ fieldName: '메모', max: '300자' })),
     })
     .superRefine((value, ctx) => {
+      if (value.expiry_date && value.purchased_date && value.expiry_date < value.purchased_date) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['expiry_date'],
+          message: ERROR_MSG.DATE.ON_OR_AFTER({ fieldName: '유통기한', baseName: '구매일' }),
+        });
+      }
+
       const minQuantity = resolveAmountMin(value.unit);
 
       if (value.quantity < minQuantity) {
@@ -143,6 +154,9 @@ export function FridgeItemAddScreen({
   const mutation = useAddFridgeItemMutation();
   const formId = 'fridge-item-add-form';
   const { data: categoryOptions = [] } = useIngredientCategoriesQuery(householdId);
+  const { data: expiryDefaults } = useCategoryExpiryDefaultsQuery(householdId);
+  // 사용자가 유통기한을 직접 수정했는지 추적 — true면 카테고리 기본값으로 덮어쓰지 않는다.
+  const isExpiryDirtyRef = useRef(false);
   const categoryIds = useMemo(
     () => categoryOptions.map((category) => category.id),
     [categoryOptions],
@@ -203,6 +217,21 @@ export function FridgeItemAddScreen({
   const quantityStep = resolveAmountStep(selectedUnit);
   const quantityMin = resolveAmountMin(selectedUnit);
 
+  // 기본 유효기간 설정이 로드되면, 사용자가 아직 유통기한을 건드리지 않았고 비어 있을 때
+  // 초기 카테고리 기본값으로 defaultValue를 채운다. (카테고리 변경 시 채움은 필드 listener에서 처리)
+  useConditionalEffect(
+    function prefillExpiryFromCategoryDefault() {
+      if (isExpiryDirtyRef.current || form.state.values.expiry_date) return;
+      const nextExpiry = computeExpiryDate(
+        form.state.values.purchased_date,
+        expiryDefaults?.[form.state.values.category_id],
+      );
+      if (nextExpiry) form.setFieldValue('expiry_date', nextExpiry);
+    },
+    [expiryDefaults] as const,
+    (previousDeps, currentDeps) => previousDeps?.[0] !== currentDeps[0],
+  );
+
   return (
     <AppScreen className="pointer-events-auto" appBar={{ title: '재료 추가' }}>
       <form
@@ -218,7 +247,19 @@ export function FridgeItemAddScreen({
         <fieldset className="flex flex-col gap-3">
           <legend className="mb-1 text-xs font-semibold text-gray-500">기본 정보</legend>
 
-          <form.Field name="category_id">
+          <form.Field
+            name="category_id"
+            listeners={{
+              onChange: ({ value }) => {
+                if (isExpiryDirtyRef.current) return;
+                const nextExpiry = computeExpiryDate(
+                  form.state.values.purchased_date,
+                  expiryDefaults?.[value],
+                );
+                form.setFieldValue('expiry_date', nextExpiry ?? '');
+              },
+            }}
+          >
             {(field) => <CategoryFormField field={field} options={categoryOptions} />}
           </form.Field>
 
@@ -437,7 +478,10 @@ export function FridgeItemAddScreen({
                 <Form.Control>
                   <DatePicker
                     value={parseDateValue(field.state.value)}
-                    onChange={(date) => field.handleChange(date ? format(date, 'yyyy-MM-dd') : '')}
+                    onChange={(date) => {
+                      isExpiryDirtyRef.current = true;
+                      field.handleChange(date ? format(date, 'yyyy-MM-dd') : '');
+                    }}
                     placeholder="유통기한을 선택하세요"
                   />
                 </Form.Control>

--- a/supabase/migrations/070_add_fridge_category_expiry_defaults.sql
+++ b/supabase/migrations/070_add_fridge_category_expiry_defaults.sql
@@ -1,11 +1,47 @@
--- Function: public.add_ingredient_with_fridge
--- Source: supabase/migrations/038_drop_legacy_category_columns_and_use_category_id.sql
---         supabase/migrations/070_add_fridge_category_expiry_defaults.sql (카테고리 기본 유효기간 반영)
--- 역할: 장보기 항목 생성과 냉장고 아이템/배치 연결을 한 트랜잭션으로 처리합니다.
--- 동작:
--- 1. ingredient를 생성하고 category_id를 정규화합니다.
--- 2. 카테고리 기본 유효기간이 설정돼 있으면 구매일 + 기본일수로 배치 expiry_date를 채웁니다.
--- 3. 동일 품목 fridge_item을 재사용하거나 없으면 생성한 뒤 batch를 추가합니다.
+-- 카테고리별 기본 유효기간(일수) 설정 테이블 추가 및 장보기 자동 유효기간 채움 반영.
+-- 가구(household) 단위로 카테고리별 기본 유효기간을 저장하고,
+-- 장보기(add_ingredient_with_fridge) 경로에서 구매일 + 기본일수로 배치 expiry_date를 자동 확정한다.
+
+create table if not exists public.fridge_category_expiry_defaults (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  category_id uuid not null references public.ingredient_categories(id) on delete cascade,
+  default_expiry_days integer not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint fridge_category_expiry_days_range check (default_expiry_days between 1 and 180),
+  constraint uq_fridge_category_expiry_defaults unique (household_id, category_id)
+);
+
+create index if not exists idx_fridge_category_expiry_defaults_household
+  on public.fridge_category_expiry_defaults(household_id);
+
+drop trigger if exists set_updated_at on public.fridge_category_expiry_defaults;
+create trigger set_updated_at before update on public.fridge_category_expiry_defaults
+for each row execute function public.handle_updated_at();
+
+alter table public.fridge_category_expiry_defaults enable row level security;
+
+create policy "fridge_category_expiry_defaults_select"
+  on public.fridge_category_expiry_defaults for select
+  using (public.is_household_member(household_id));
+
+create policy "fridge_category_expiry_defaults_insert"
+  on public.fridge_category_expiry_defaults for insert
+  with check (public.is_household_member(household_id));
+
+create policy "fridge_category_expiry_defaults_update"
+  on public.fridge_category_expiry_defaults for update
+  using (public.is_household_member(household_id))
+  with check (public.is_household_member(household_id));
+
+create policy "fridge_category_expiry_defaults_delete"
+  on public.fridge_category_expiry_defaults for delete
+  using (public.is_household_member(household_id));
+
+grant select, insert, update, delete on public.fridge_category_expiry_defaults to authenticated;
+
+-- add_ingredient_with_fridge: 카테고리 기본 유효기간이 설정돼 있으면 배치 expiry_date를 구매일 + 기본일수로 채운다.
 create or replace function public.add_ingredient_with_fridge(
   p_household_id uuid,
   p_name text,


### PR DESCRIPTION
## 개요

냉장고 재고 등록 시 유효기간이 비어 있던 문제를 개선한다. 가구 단위로 카테고리별 기본 유효기간(예: 채소 14일, 두부/콩류 7일)을 설정해두면, 새 재고가 등록될 때 구매일 기준으로 유통기한이 자동으로 채워진다.

## 변경 사항

### DB (`070` 마이그레이션)
- `fridge_category_expiry_defaults` 테이블 신설 — `household_id + category_id + default_expiry_days`(1~180 체크), `unique(household_id, category_id)`, 가구원 RLS
- `add_ingredient_with_fridge` RPC 수정 — 카테고리 기본일수가 설정돼 있으면 `구매일 + 일수`로 배치 `expiry_date` 자동 확정 (미설정이면 null 유지, 과거 날짜여도 그대로 저장)

### API
- `GET/PUT /api/fridge/category-expiry-defaults` — 가구 카테고리별 기본 유효기간 목록 조회 / 단건 upsert(즉시 저장), `days: null`이면 삭제(미설정으로 복귀)

### 설정 UI
- `FridgeFilterSettingsScreen` 안에 인라인 섹션 `CategoryExpiryDefaultsSection` 추가
- 카테고리 행 탭 → `SingleSelectBottomSheet`(WheelPicker + 확인 CTA 재사용) → "설정 안 함" + 1~180일 선택 → 확인 시 즉시 upsert
- `householdId`는 `useProfileQuery`로 조회

### 직접 추가 폼 (`FridgeItemAddScreen`)
- 카테고리 기본값을 유통기한 **defaultValue**로 프리필
- dirty 추적: 사용자가 직접 수정하면 고정, 구매일 변경 시 재계산 안 함, 카테고리 변경 시 미수정 상태면 재계산
- `유통기한 >= 구매일` 유효성 검사 추가 (`ERROR_MSG.DATE.ON_OR_AFTER`)

## 동작 정책
- 소급 없음: 설정 변경은 신규 등록에만 적용, 기존 배치는 건드리지 않음
- 미설정 카테고리는 유통기한 null 유지
- 장보기/영수증은 백엔드(RPC) 자동 확정, 직접 추가는 프론트 defaultValue 프리필

## 영향 범위
- 라우트: `/fridge`(필터 설정, 재료 추가), `/store`(장보기·영수증 등록 자동 채움)
- 신규 API: `/api/fridge/category-expiry-defaults`

## 검증
- `pnpm lint` (tsc 포함) 통과
- `pnpm build` 성공, 신규 라우트 빌드 확인

## 배포 시 주의
- `070` 마이그레이션을 DB에 반영해야 한다 (`supabase db push`). 미반영 시 설정/자동 채움이 실패한다.