### PR TITLE
feat: 식단 소진을 묶음 소진과 전부 소진으로 분리

### DIFF
--- a/app/api/meals/route.ts
+++ b/app/api/meals/route.ts
@@ -10,7 +10,7 @@ import { dispatchHouseholdNotification } from '@/commons/lib/http/dispatchHouseh
 
 import { type MealType } from '@/entities/meal';
 
-type IngredientUsageStatus = 'used' | 'depleted';
+type IngredientUsageStatus = 'used' | 'depleted' | 'depleted_batch';
 type IngredientUnit = 'count' | 'g' | 'kg' | 'ml' | 'l';
 
 interface UpsertMealIngredient {
@@ -19,7 +19,7 @@ interface UpsertMealIngredient {
   unit?: IngredientUnit;
   /** 개 단위: 수량. g/kg/ml/L 단위: 없음 */
   amount?: number | null;
-  /** g/kg/ml/L 단위: 'used' | 'depleted'. 개 단위: 없음 */
+  /** g/kg/ml/L 단위: 'used' | 'depleted_batch' | 'depleted'. 개 단위: 없음 */
   usage_status?: IngredientUsageStatus;
 }
 
@@ -50,7 +50,11 @@ function normalizeIngredient(ingredient: UpsertMealIngredient) {
 
   if (isUsageStatusUnit(ingredient.unit)) {
     // g/kg/ml/L 품목: usage_status 기반
-    if (ingredient.usage_status === 'used' || ingredient.usage_status === 'depleted') {
+    if (
+      ingredient.usage_status === 'used' ||
+      ingredient.usage_status === 'depleted' ||
+      ingredient.usage_status === 'depleted_batch'
+    ) {
       return { fridge_item_id: ingredient.fridge_item_id, usage_status: ingredient.usage_status };
     }
     return null;

--- a/src/entities/meal/model/types.ts
+++ b/src/entities/meal/model/types.ts
@@ -10,8 +10,8 @@ export interface DishIngredient {
   fridge_item_id: string;
   /** 사용량 — 개 단위: 숫자, g/kg 단위: null */
   amount: number | null;
-  /** 사용 상태 — g/kg 단위: 'used' | 'depleted', 개 단위: 'used' */
-  usage_status: 'used' | 'depleted' | null;
+  /** 사용 상태 — g/kg 단위: 'used' | 'depleted_batch' | 'depleted', 개 단위: 'used' */
+  usage_status: 'used' | 'depleted' | 'depleted_batch' | null;
   /** join된 냉장고 품목 정보 */
   fridge_items: { unit: 'count' | 'g' | 'kg'; name: string; category_id: string } | null;
   created_at: string;

--- a/src/features/meal/api/mutations.ts
+++ b/src/features/meal/api/mutations.ts
@@ -12,8 +12,8 @@ export interface MealEditorDishInput {
     fridge_item_id: string;
     /** 개 단위: 수량. g/kg/ml/L 단위: 0 (Route Handler에서 무시) */
     amount?: number;
-    /** 항상 포함 — g/kg/ml/L: 'used' | 'depleted'. 개 단위: 항상 'used' */
-    usage_status: 'used' | 'depleted';
+    /** 항상 포함 — g/kg/ml/L: 'used' | 'depleted_batch' | 'depleted'. 개 단위: 항상 'used' */
+    usage_status: 'used' | 'depleted' | 'depleted_batch';
     /** 냉장고 품목 단위 — Route Handler에서 g/kg/ml/L vs 개 판별에 사용 */
     unit?: IngredientUnit;
   }>;

--- a/src/features/meal/lib/types.ts
+++ b/src/features/meal/lib/types.ts
@@ -1,12 +1,15 @@
 import { type IngredientUnit } from '@/entities/ingredient';
 
-type IngredientUsageStatus = 'used' | 'depleted';
+type IngredientUsageStatus = 'used' | 'depleted' | 'depleted_batch';
 
 interface EditorIngredient {
   fridge_item_id: string;
   /** 개 단위: 수량. g/kg, ml/L 단위: 0 (사용 안 함) */
   amount: number;
-  /** 항상 포함 — g/kg, ml/L: 'used' | 'depleted'. 개 단위: 항상 'used' */
+  /**
+   * 항상 포함 — 개 단위: 항상 'used'.
+   * g/kg, ml/L: 'used'(재고 유지) | 'depleted_batch'(가장 오래된 구매분 1개 소진) | 'depleted'(전부 소진)
+   */
   usage_status: IngredientUsageStatus;
   /** 냉장고 품목 단위 — 재료 선택 시 fridgeItems에서 주입 */
   unit?: IngredientUnit;

--- a/src/features/meal/model/schema.ts
+++ b/src/features/meal/model/schema.ts
@@ -37,7 +37,7 @@ function createMealEditorDishesSchema(
                 .trim()
                 .min(1, ERROR_MSG.SELECT.REQUIRED({ fieldName: '재료' })),
               amount: z.number().min(0, ERROR_MSG.RANGE.MIN({ fieldName: '재료 수량', min: 0 })),
-              usage_status: z.enum(['used', 'depleted']),
+              usage_status: z.enum(['used', 'depleted', 'depleted_batch']),
             }),
           )
           .min(1, '메뉴마다 재료를 1개 이상 추가해 주세요'),

--- a/src/features/meal/ui/MealIngredientRow.tsx
+++ b/src/features/meal/ui/MealIngredientRow.tsx
@@ -154,10 +154,10 @@ function MealIngredientRow({
             disabled={!selectedIngredient}
           >
             <SegmentControl.Item value="used">사용</SegmentControl.Item>
-            <SegmentControl.Item value="depleted_batch">묶음 소진</SegmentControl.Item>
-            <SegmentControl.Item value="depleted">전부 소진</SegmentControl.Item>
+            <SegmentControl.Item value="depleted_batch">일부 소진</SegmentControl.Item>
+            <SegmentControl.Item value="depleted">전량 소진</SegmentControl.Item>
           </SegmentControl>
-          <p className="text-xs text-gray-400">‘묶음 소진’은 가장 오래된 구매분 하나만 비워요.</p>
+          <p className="text-xs text-gray-400">‘일부 소진’은 가장 오래된 구매분 하나만 비워요.</p>
         </div>
       ) : (
         <MealIngredientWeightControl

--- a/src/features/meal/ui/MealIngredientRow.tsx
+++ b/src/features/meal/ui/MealIngredientRow.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronRight, X } from 'lucide-react';
 
-import { Badge, Button, Checkbox, Select } from '@/commons/ui';
+import { Badge, Button, SegmentControl, Select } from '@/commons/ui';
 import { cn } from '@/commons/lib';
 
 import { isVolumeUnit, isWeightUnit } from '@/entities/ingredient';
@@ -146,28 +146,19 @@ function MealIngredientRow({
       </div>
 
       {isWeightUnit(selectedUnit) || isVolumeUnit(selectedUnit) ? (
-        <label
-          className={cn(
-            'flex cursor-pointer items-center gap-2',
-            !selectedIngredient && 'cursor-not-allowed',
-          )}
-        >
-          <Checkbox
-            checked={ingredient.usage_status === 'depleted'}
-            onCheckedChange={(checked) =>
-              onUsageStatusChange(checked === true ? 'depleted' : 'used')
-            }
+        <div className="space-y-1">
+          <SegmentControl
+            size="sm"
+            value={ingredient.usage_status}
+            onValueChange={(value) => onUsageStatusChange(value as IngredientUsageStatus)}
             disabled={!selectedIngredient}
-          />
-          <span
-            className={cn(
-              'text-sm',
-              !selectedIngredient ? 'text-muted-foreground' : 'text-gray-700',
-            )}
           >
-            소진됨
-          </span>
-        </label>
+            <SegmentControl.Item value="used">사용</SegmentControl.Item>
+            <SegmentControl.Item value="depleted_batch">묶음 소진</SegmentControl.Item>
+            <SegmentControl.Item value="depleted">전부 소진</SegmentControl.Item>
+          </SegmentControl>
+          <p className="text-xs text-gray-400">‘묶음 소진’은 가장 오래된 구매분 하나만 비워요.</p>
+        </div>
       ) : (
         <MealIngredientWeightControl
           min={sliderMin}

--- a/supabase/migrations/071_add_depleted_batch_usage_status.sql
+++ b/supabase/migrations/071_add_depleted_batch_usage_status.sql
@@ -1,13 +1,20 @@
--- Function: public.upsert_meal_with_usage
--- Source: supabase/migrations/071_add_depleted_batch_usage_status.sql
--- 역할: 식단 저장 시 dish/ingredient와 배치 사용량 차감을 원자적으로 처리합니다.
+-- Migration: 071_add_depleted_batch_usage_status
+-- 역할: g/kg·ml/L 품목 소진을 '한 묶음(가장 오래된 구매분) 소진'과 '전부 소진'으로 분리합니다.
 -- 동작:
--- 1. 기존 meal usage를 롤백한 뒤 새 dishes/ingredients를 재저장합니다.
--- 2. usage_status='used' (g/kg): dish_ingredients에만 기록, 배치 변화 없음.
--- 3. usage_status='depleted_batch' (g/kg): FIFO 기준 가장 오래된 배치 1개만 0으로 소진, meal_batch_usages 기록.
--- 4. usage_status='depleted' (g/kg): 해당 품목 전체 배치를 0으로 소진, meal_batch_usages 기록.
--- 5. usage_status 없이 amount>0 (개): FIFO 배치 차감 후 부족 시 도메인 예외 발생.
--- 6. meals 테이블에 created_by(auth.uid())를 기록합니다 (신규 등록 시에만, 수정 시 유지).
+-- 1. dish_ingredients.usage_status CHECK 제약에 'depleted_batch' 값을 추가합니다.
+-- 2. upsert_meal_with_usage RPC를 갱신해 usage_status별 소진 범위를 분기합니다.
+--    - 'depleted_batch': FIFO 기준 가장 오래된 배치 1개만 quantity→0
+--    - 'depleted'      : 해당 품목 전체 배치 quantity→0 (기존 동작 유지)
+
+-- Step 1: CHECK 제약 갱신 ('used' | 'depleted' | 'depleted_batch')
+ALTER TABLE public.dish_ingredients
+  DROP CONSTRAINT IF EXISTS dish_ingredients_usage_status_check;
+
+ALTER TABLE public.dish_ingredients
+  ADD CONSTRAINT dish_ingredients_usage_status_check
+  CHECK (usage_status IN ('used', 'depleted', 'depleted_batch'));
+
+-- Step 2: RPC 갱신
 create or replace function public.upsert_meal_with_usage(
   p_household_id uuid,
   p_date date,
@@ -169,7 +176,7 @@ begin
     end if;
   end loop;
 
-  -- g/kg 한 묶음 소진: FIFO 기준 가장 오래된 배치 1개만 quantity → 0
+  -- g/kg 한 묶음 소진: FIFO 기준 가장 오래된 배치 1개만 quantity→0
   for v_depleted in
     select distinct di.fridge_item_id
     from public.dish_ingredients di


### PR DESCRIPTION
- g/kg·ml/L 품목 소진 상태에 depleted_batch(가장 오래된 구매분 1개 소진)를 추가하고 depleted를 전부 소진으로 유지
- upsert_meal_with_usage RPC에 FIFO 단일 배치 소진 분기 추가, usage_status CHECK 제약 확장 (migration 071)
- 식단 재료 UI를 소진됨 체크박스에서 사용/묶음 소진/전부 소진 SegmentControl로 교체
- 타입/스키마/라우트 핸들러의 usage_status 유니온 반영