### PR TITLE
feat: 식단 재료를 배치(구매분) 단위 선택으로 전환

### DIFF
--- a/app/api/meals/fridge-items/route.ts
+++ b/app/api/meals/fridge-items/route.ts
@@ -24,7 +24,9 @@ export const GET = withAuth(async (req: NextRequest, { userId, supabase }) => {
 
   let query = supabase
     .from('fridge_items')
-    .select('id, name, brand, total_count, unit, fridge_item_batches(purchased_date, quantity)')
+    .select(
+      'id, name, brand, total_count, unit, fridge_item_batches(id, purchased_date, quantity, expiry_date, deleted_at)',
+    )
     .eq('household_id', householdId)
     .is('deleted_at', null)
     .order('name', { ascending: true })

--- a/app/api/meals/route.ts
+++ b/app/api/meals/route.ts
@@ -10,16 +10,18 @@ import { dispatchHouseholdNotification } from '@/commons/lib/http/dispatchHouseh
 
 import { type MealType } from '@/entities/meal';
 
-type IngredientUsageStatus = 'used' | 'depleted' | 'depleted_batch';
+type IngredientUsageStatus = 'used' | 'depleted';
 type IngredientUnit = 'count' | 'g' | 'kg' | 'ml' | 'l';
 
 interface UpsertMealIngredient {
   fridge_item_id: string;
+  /** 선택한 배치(구매분) ID — 소진/차감 대상 배치 */
+  batch_id?: string | null;
   /** 냉장고 품목 단위 — g/kg/ml/L vs 개 판별 기준 */
   unit?: IngredientUnit;
   /** 개 단위: 수량. g/kg/ml/L 단위: 없음 */
   amount?: number | null;
-  /** g/kg/ml/L 단위: 'used' | 'depleted_batch' | 'depleted'. 개 단위: 없음 */
+  /** g/kg/ml/L 단위: 'used' | 'depleted'. 개 단위: 없음 */
   usage_status?: IngredientUsageStatus;
 }
 
@@ -48,14 +50,16 @@ function isUsageStatusUnit(unit?: IngredientUnit) {
 function normalizeIngredient(ingredient: UpsertMealIngredient) {
   if (!ingredient.fridge_item_id) return null;
 
+  const batchId = ingredient.batch_id || null;
+
   if (isUsageStatusUnit(ingredient.unit)) {
     // g/kg/ml/L 품목: usage_status 기반
-    if (
-      ingredient.usage_status === 'used' ||
-      ingredient.usage_status === 'depleted' ||
-      ingredient.usage_status === 'depleted_batch'
-    ) {
-      return { fridge_item_id: ingredient.fridge_item_id, usage_status: ingredient.usage_status };
+    if (ingredient.usage_status === 'used' || ingredient.usage_status === 'depleted') {
+      return {
+        fridge_item_id: ingredient.fridge_item_id,
+        batch_id: batchId,
+        usage_status: ingredient.usage_status,
+      };
     }
     return null;
   }
@@ -63,7 +67,7 @@ function normalizeIngredient(ingredient: UpsertMealIngredient) {
   // 개 품목: amount 기반
   const amount = toSafePositiveAmount(ingredient.amount);
   if (amount <= 0) return null;
-  return { fridge_item_id: ingredient.fridge_item_id, amount };
+  return { fridge_item_id: ingredient.fridge_item_id, batch_id: batchId, amount };
 }
 
 /** GET /api/meals?householdId=&date= — 특정 날짜 식단 조회 */
@@ -78,7 +82,9 @@ export const GET = withAuth(async (req: NextRequest, { supabase }) => {
 
   const { data: meals, error: mealsError } = await supabase
     .from('meals')
-    .select('*, dishes(*, ingredients:dish_ingredients(*, fridge_items(unit, name, category_id)))')
+    .select(
+      '*, dishes(*, ingredients:dish_ingredients(*, fridge_items(unit, name, category_id), fridge_item_batches(id, purchased_date, quantity, expiry_date)))',
+    )
     .eq('household_id', householdId)
     .eq('date', date)
     .order('type', { ascending: true });

--- a/src/apps/stackflow/StackFlow.tsx
+++ b/src/apps/stackflow/StackFlow.tsx
@@ -35,10 +35,15 @@ import {
 import {
   MealEditorScreen,
   FridgeItemSearchScreen,
+  FridgeBatchSelectScreen,
   setPendingFridgeItemCallback,
   resolvePendingFridgeItemCallback,
   clearPendingFridgeItemCallback,
+  setPendingFridgeBatchCallback,
+  resolvePendingFridgeBatchCallback,
+  clearPendingFridgeBatchCallback,
   type FridgeItemSearchOption,
+  type FridgeBatchSelectOption,
 } from '@/features/meal';
 import { NotificationScreen, NotificationSettingsScreen } from '@/features/notification';
 import { ProfileEditScreen, ProfileSettingsScreen } from '@/features/profile';
@@ -313,6 +318,18 @@ function MealEditorActivity({
     });
   }
 
+  function openFridgeBatchSelect(
+    batches: FridgeBatchSelectOption[],
+    unit: IngredientUnit,
+    onSelectBatchId: (batchId: string) => void,
+  ) {
+    setPendingFridgeBatchCallback(onSelectBatchId);
+    push('FridgeBatchSelectActivity', {
+      batches,
+      unit,
+    });
+  }
+
   return (
     <MealEditorScreen
       onClose={pop}
@@ -321,6 +338,7 @@ function MealEditorActivity({
       type={params.type}
       meal={params.meal}
       onOpenFridgeItemSearch={openFridgeItemSearch}
+      onOpenFridgeBatchSelect={openFridgeBatchSelect}
     />
   );
 }
@@ -512,6 +530,36 @@ function FridgeItemSearchActivity({
   );
 }
 
+function FridgeBatchSelectActivity({
+  params,
+}: {
+  params: {
+    batches?: FridgeBatchSelectOption[];
+    unit?: IngredientUnit;
+  };
+}) {
+  const { pop } = useActions();
+
+  function handleSelectBatch(batchId: string) {
+    resolvePendingFridgeBatchCallback(batchId);
+    pop();
+  }
+
+  function handleClose() {
+    clearPendingFridgeBatchCallback();
+    pop();
+  }
+
+  return (
+    <FridgeBatchSelectScreen
+      onClose={handleClose}
+      onSelectBatch={handleSelectBatch}
+      batches={params.batches}
+      unit={params.unit}
+    />
+  );
+}
+
 const appStackFlow = stackflow({
   transitionDuration: 360,
   initialActivity: () => 'IdleActivity',
@@ -534,6 +582,7 @@ const appStackFlow = stackflow({
     ProfileEditActivity,
     ProductNameSearchActivity,
     FridgeItemSearchActivity,
+    FridgeBatchSelectActivity,
     PromptIngredientAddActivity,
     PromptIngredientStagingActivity,
     PromptIngredientStagingEditActivity,
@@ -560,6 +609,7 @@ const appStackFlow = stackflow({
         ProfileEditActivity: '/profile/edit',
         ProductNameSearchActivity: '/search/product-name',
         FridgeItemSearchActivity: '/search/fridge-item',
+        FridgeBatchSelectActivity: '/search/fridge-batch',
         PromptIngredientAddActivity: '/ingredient/ai/add',
         PromptIngredientStagingActivity: '/ingredient/ai/staging',
         PromptIngredientStagingEditActivity: '/ingredient/ai/staging/edit',

--- a/src/entities/meal/model/types.ts
+++ b/src/entities/meal/model/types.ts
@@ -8,12 +8,21 @@ export interface DishIngredient {
   dish_id: string;
   /** 사용된 냉장고 재료 ID */
   fridge_item_id: string;
+  /** 선택한 배치(구매분) ID — 소진/차감 대상 배치 */
+  batch_id: string | null;
   /** 사용량 — 개 단위: 숫자, g/kg 단위: null */
   amount: number | null;
-  /** 사용 상태 — g/kg 단위: 'used' | 'depleted_batch' | 'depleted', 개 단위: 'used' */
-  usage_status: 'used' | 'depleted' | 'depleted_batch' | null;
+  /** 사용 상태 — g/kg 단위: 'used' | 'depleted', 개 단위: 'used' */
+  usage_status: 'used' | 'depleted' | null;
   /** join된 냉장고 품목 정보 */
   fridge_items: { unit: 'count' | 'g' | 'kg'; name: string; category_id: string } | null;
+  /** join된 선택 배치 정보 */
+  fridge_item_batches: {
+    id: string;
+    purchased_date: string;
+    quantity: number;
+    expiry_date: string | null;
+  } | null;
   created_at: string;
 }
 

--- a/src/features/meal/api/mutations.ts
+++ b/src/features/meal/api/mutations.ts
@@ -10,10 +10,12 @@ export interface MealEditorDishInput {
   name: string;
   ingredients: Array<{
     fridge_item_id: string;
+    /** 선택한 배치(구매분) ID — 소진/차감 대상 */
+    batch_id?: string;
     /** 개 단위: 수량. g/kg/ml/L 단위: 0 (Route Handler에서 무시) */
     amount?: number;
-    /** 항상 포함 — g/kg/ml/L: 'used' | 'depleted_batch' | 'depleted'. 개 단위: 항상 'used' */
-    usage_status: 'used' | 'depleted' | 'depleted_batch';
+    /** 항상 포함 — g/kg/ml/L: 'used' | 'depleted'. 개 단위: 항상 'used' */
+    usage_status: 'used' | 'depleted';
     /** 냉장고 품목 단위 — Route Handler에서 g/kg/ml/L vs 개 판별에 사용 */
     unit?: IngredientUnit;
   }>;

--- a/src/features/meal/api/queries.ts
+++ b/src/features/meal/api/queries.ts
@@ -12,7 +12,9 @@ export interface MealFridgeItemOption extends Pick<
   FridgeItem,
   'id' | 'name' | 'brand' | 'total_count' | 'unit'
 > {
-  fridge_item_batches: Array<Pick<FridgeItemBatch, 'purchased_date' | 'quantity'>>;
+  fridge_item_batches: Array<
+    Pick<FridgeItemBatch, 'id' | 'purchased_date' | 'quantity' | 'expiry_date' | 'deleted_at'>
+  >;
 }
 
 /** 특정 날짜 식단 조회 — 날짜 전환 시 이전 데이터를 유지해 깜빡임을 방지한다 */

--- a/src/features/meal/index.ts
+++ b/src/features/meal/index.ts
@@ -14,10 +14,16 @@ export { MealCardList } from './ui/MealCardList';
 export { MealDateStrip } from './ui/MealDateStrip';
 export { MealEditorScreen } from './ui/MealEditorScreen';
 export { FridgeItemSearchScreen } from './ui/FridgeItemSearchScreen';
+export { FridgeBatchSelectScreen } from './ui/FridgeBatchSelectScreen';
 
-export type { FridgeItemSearchOption } from './lib';
+export type { FridgeBatchSelectOption, FridgeItemSearchOption } from './lib';
 export {
   setPendingFridgeItemCallback,
   resolvePendingFridgeItemCallback,
   clearPendingFridgeItemCallback,
 } from './model/fridgeItemSearchStore';
+export {
+  setPendingFridgeBatchCallback,
+  resolvePendingFridgeBatchCallback,
+  clearPendingFridgeBatchCallback,
+} from './model/fridgeBatchSelectStore';

--- a/src/features/meal/lib/dishes.ts
+++ b/src/features/meal/lib/dishes.ts
@@ -32,7 +32,12 @@ function appendIngredient(dishes: EditorDish[], dishIndex: number) {
           ...dish,
           ingredients: [
             ...dish.ingredients,
-            { fridge_item_id: '', amount: 0, usage_status: 'used' as IngredientUsageStatus },
+            {
+              fridge_item_id: '',
+              batch_id: '',
+              amount: 0,
+              usage_status: 'used' as IngredientUsageStatus,
+            },
           ],
         }
       : dish,
@@ -76,6 +81,35 @@ function replaceIngredientItem(
           ? {
               ...ingredient,
               fridge_item_id: fridgeItemId,
+              batch_id: '',
+              amount: 0,
+              usage_status: 'used' as IngredientUsageStatus,
+            }
+          : ingredient,
+      ),
+    };
+  });
+}
+
+/**
+ * @description 지정한 메뉴/재료의 선택 배치(구매분)를 교체하고 수량을 초기화합니다.
+ */
+function replaceIngredientBatch(
+  dishes: EditorDish[],
+  dishIndex: number,
+  ingredientIndex: number,
+  batchId: string,
+) {
+  return dishes.map((dish, index) => {
+    if (index !== dishIndex) return dish;
+
+    return {
+      ...dish,
+      ingredients: dish.ingredients.map((ingredient, currentIndex) =>
+        currentIndex === ingredientIndex
+          ? {
+              ...ingredient,
+              batch_id: batchId,
               amount: 0,
               usage_status: 'used' as IngredientUsageStatus,
             }
@@ -151,6 +185,7 @@ export {
   excludeIngredient,
   renameDish,
   replaceIngredientAmount,
+  replaceIngredientBatch,
   replaceIngredientItem,
   replaceIngredientUsageStatus,
   reorderDishes,

--- a/src/features/meal/lib/index.ts
+++ b/src/features/meal/lib/index.ts
@@ -1,9 +1,11 @@
 export type {
   EditorDish,
   EditorIngredient,
+  FridgeBatchInfo,
+  FridgeBatchSelectOption,
   FridgeItemSearchOption,
-  FridgeStockInfo,
   IngredientUsageStatus,
+  MealFridgeBatch,
   MealFridgeItem,
 } from './types';
 
@@ -15,7 +17,7 @@ export {
   resolveWeightSliderMin,
   resolveWeightSliderStep,
 } from './unit';
-export { createFridgeStockInfoById } from './stock';
+export { createFridgeBatchInfoById } from './stock';
 export {
   appendDish,
   appendIngredient,
@@ -23,6 +25,7 @@ export {
   excludeIngredient,
   renameDish,
   replaceIngredientAmount,
+  replaceIngredientBatch,
   replaceIngredientItem,
   replaceIngredientUsageStatus,
   reorderDishes,

--- a/src/features/meal/lib/stock.ts
+++ b/src/features/meal/lib/stock.ts
@@ -1,29 +1,29 @@
 import { normalizeAmount } from '../model/amount';
 
-import { type FridgeStockInfo, type MealFridgeItem } from './types';
+import { type FridgeBatchInfo, type MealFridgeItem } from './types';
 import { resolveIngredientUnitLabel } from './unit';
 
 /**
- * @description 재고 목록을 id 기반 조회 맵(품목명/가용수량/단위)으로 변환합니다.
+ * @description 재고 배치 목록을 batch_id 기반 조회 맵(품목명/잔여수량/단위)으로 변환합니다.
  */
-function createFridgeStockInfoById(fridgeItems: MealFridgeItem[]) {
-  const stockInfoById: Record<string, FridgeStockInfo> = {};
+function createFridgeBatchInfoById(fridgeItems: MealFridgeItem[]) {
+  const batchInfoById: Record<string, FridgeBatchInfo> = {};
 
   fridgeItems.forEach((item) => {
-    const availableAmount = Number(item.total_count);
-    const normalizedAvailableAmount = normalizeAmount(availableAmount);
+    item.fridge_item_batches.forEach((batch) => {
+      const quantity = Number(batch.quantity);
+      const normalizedQuantity = normalizeAmount(quantity);
 
-    stockInfoById[item.id] = {
-      itemName: item.name,
-      availableAmount: Number.isFinite(availableAmount)
-        ? Math.max(0, normalizedAvailableAmount)
-        : 0,
-      unit: item.unit,
-      unitLabel: resolveIngredientUnitLabel(item.unit),
-    };
+      batchInfoById[batch.id] = {
+        itemName: item.name,
+        quantity: Number.isFinite(quantity) ? Math.max(0, normalizedQuantity) : 0,
+        unit: item.unit,
+        unitLabel: resolveIngredientUnitLabel(item.unit),
+      };
+    });
   });
 
-  return stockInfoById;
+  return batchInfoById;
 }
 
-export { createFridgeStockInfoById };
+export { createFridgeBatchInfoById };

--- a/src/features/meal/lib/types.ts
+++ b/src/features/meal/lib/types.ts
@@ -1,14 +1,24 @@
 import { type IngredientUnit } from '@/entities/ingredient';
 
-type IngredientUsageStatus = 'used' | 'depleted' | 'depleted_batch';
+type IngredientUsageStatus = 'used' | 'depleted';
+
+/** 냉장고 품목의 배치(구매분) — 식단 편집에서 선택 대상 */
+interface MealFridgeBatch {
+  id: string;
+  purchased_date: string;
+  quantity: number;
+  expiry_date: string | null;
+}
 
 interface EditorIngredient {
   fridge_item_id: string;
+  /** 선택한 배치(구매분) ID — 재료 선택 시 지정 (배치 1개면 자동, 2개+면 선택) */
+  batch_id: string;
   /** 개 단위: 수량. g/kg, ml/L 단위: 0 (사용 안 함) */
   amount: number;
   /**
    * 항상 포함 — 개 단위: 항상 'used'.
-   * g/kg, ml/L: 'used'(재고 유지) | 'depleted_batch'(가장 오래된 구매분 1개 소진) | 'depleted'(전부 소진)
+   * g/kg, ml/L: 'used'(재고 유지) | 'depleted'(선택한 배치 소진)
    */
   usage_status: IngredientUsageStatus;
   /** 냉장고 품목 단위 — 재료 선택 시 fridgeItems에서 주입 */
@@ -20,9 +30,10 @@ interface EditorDish {
   ingredients: EditorIngredient[];
 }
 
-interface FridgeStockInfo {
+/** 배치(구매분) 단위 재고 정보 — 스키마 검증/슬라이더 상한 계산용 */
+interface FridgeBatchInfo {
   itemName: string;
-  availableAmount: number;
+  quantity: number;
   unit: IngredientUnit;
   unitLabel: string;
 }
@@ -33,6 +44,8 @@ interface MealFridgeItem {
   brand?: string | null;
   total_count: number | string;
   unit: IngredientUnit;
+  /** 활성(미삭제) 배치 목록 — 구매일 오름차순 */
+  fridge_item_batches: MealFridgeBatch[];
 }
 
 /** 식단 재고 선택 Screen에 전달되는 항목 — 브랜드별로 구분된 개별 fridge_item */
@@ -43,11 +56,21 @@ interface FridgeItemSearchOption {
   depleted: boolean;
 }
 
+/** 식단 배치 선택 Screen에 전달되는 항목 — 한 품목의 개별 구매분 */
+interface FridgeBatchSelectOption {
+  id: string;
+  purchasedDate: string;
+  quantity: number;
+  expiryDate: string | null;
+}
+
 export type {
   EditorDish,
   EditorIngredient,
+  FridgeBatchInfo,
+  FridgeBatchSelectOption,
   FridgeItemSearchOption,
-  FridgeStockInfo,
   IngredientUsageStatus,
+  MealFridgeBatch,
   MealFridgeItem,
 };

--- a/src/features/meal/model/adapters.ts
+++ b/src/features/meal/model/adapters.ts
@@ -1,6 +1,7 @@
 import { type Meal } from '@/entities/meal';
 
-import { type EditorDish } from '../lib';
+import { type MealFridgeItemOption } from '../api/queries';
+import { type EditorDish, type MealFridgeItem } from '../lib';
 
 import { addAmount, normalizeAmount } from './amount';
 
@@ -18,6 +19,7 @@ function toEditorDishes(meal: Meal | null): EditorDish[] {
       name: dish.name === '[이름 없음]' ? '' : dish.name,
       ingredients: (dish.ingredients ?? []).map((ingredient) => ({
         fridge_item_id: ingredient.fridge_item_id,
+        batch_id: ingredient.batch_id ?? '',
         amount: normalizeAmount(Number(ingredient.amount ?? 0)),
         unit: ingredient.fridge_items?.unit ?? undefined,
         usage_status: ingredient.usage_status ?? 'used',
@@ -26,14 +28,37 @@ function toEditorDishes(meal: Meal | null): EditorDish[] {
 }
 
 /**
- * @description dishes 배열에서 재료별 총 사용량 맵을 생성합니다.
+ * @description 식단 편집용 재고 조회 결과를 배치(활성·구매일순) 포함 뷰 모델로 변환합니다.
  */
-function createInUseStockAmountByItemId(dishes: EditorDish[]) {
+function toMealFridgeItems(options: MealFridgeItemOption[]): MealFridgeItem[] {
+  return options.map((option) => ({
+    id: option.id,
+    name: option.name,
+    brand: option.brand,
+    total_count: option.total_count,
+    unit: option.unit,
+    fridge_item_batches: option.fridge_item_batches
+      .filter((batch) => batch.deleted_at === null)
+      .slice()
+      .sort((a, b) => a.purchased_date.localeCompare(b.purchased_date))
+      .map((batch) => ({
+        id: batch.id,
+        purchased_date: batch.purchased_date,
+        quantity: Number(batch.quantity),
+        expiry_date: batch.expiry_date,
+      })),
+  }));
+}
+
+/**
+ * @description dishes 배열에서 배치별 총 사용량 맵을 생성합니다.
+ */
+function createInUseStockAmountByBatchId(dishes: EditorDish[]) {
   return dishes.reduce<Record<string, number>>((accumulator, dish) => {
     dish.ingredients.forEach((ingredient) => {
-      if (!ingredient.fridge_item_id) return;
-      accumulator[ingredient.fridge_item_id] = addAmount(
-        accumulator[ingredient.fridge_item_id] ?? 0,
+      if (!ingredient.batch_id) return;
+      accumulator[ingredient.batch_id] = addAmount(
+        accumulator[ingredient.batch_id] ?? 0,
         ingredient.amount,
       );
     });
@@ -42,4 +67,4 @@ function createInUseStockAmountByItemId(dishes: EditorDish[]) {
   }, {});
 }
 
-export { createInUseStockAmountByItemId, toEditorDishes };
+export { createInUseStockAmountByBatchId, toEditorDishes, toMealFridgeItems };

--- a/src/features/meal/model/fridgeBatchSelectStore.ts
+++ b/src/features/meal/model/fridgeBatchSelectStore.ts
@@ -1,0 +1,32 @@
+/**
+ * @description 식단 배치 선택 Screen에서 선택된 batch_id를 이전 화면으로 전달하기 위한 단일 콜백 저장소.
+ * Stackflow params는 함수 직렬화가 불가능하므로, 모듈 스코프에 단일 콜백을 보관하고
+ * 배치 선택 화면이 열리기 직전에 등록, 선택 완료 또는 취소 시 실행·해제한다.
+ * 배치 선택 Activity는 항상 한 번에 하나만 열리므로 단일 변수로 충분하다.
+ */
+
+type SelectCallback = (batchId: string) => void;
+
+let pendingCallback: SelectCallback | null = null;
+
+/**
+ * @description 배치 선택 콜백을 등록한다. 기존 콜백이 있으면 덮어쓴다.
+ */
+export function setPendingFridgeBatchCallback(callback: SelectCallback) {
+  pendingCallback = callback;
+}
+
+/**
+ * @description 등록된 콜백을 실행하고 초기화한다.
+ */
+export function resolvePendingFridgeBatchCallback(batchId: string) {
+  pendingCallback?.(batchId);
+  pendingCallback = null;
+}
+
+/**
+ * @description 등록된 콜백을 실행하지 않고 초기화한다 (취소/언마운트 시).
+ */
+export function clearPendingFridgeBatchCallback() {
+  pendingCallback = null;
+}

--- a/src/features/meal/model/index.ts
+++ b/src/features/meal/model/index.ts
@@ -1,4 +1,4 @@
-export { createInUseStockAmountByItemId, toEditorDishes } from './adapters';
+export { createInUseStockAmountByBatchId, toEditorDishes, toMealFridgeItems } from './adapters';
 export {
   addAmount,
   isGreaterAmount,

--- a/src/features/meal/model/mealEditorContext.ts
+++ b/src/features/meal/model/mealEditorContext.ts
@@ -7,9 +7,10 @@ import { type EditorDish, type MealFridgeItem } from '../lib';
 interface MealEditorContextValue {
   dishes: EditorDish[];
   fridgeItems: MealFridgeItem[];
-  inUseStockAmountByItemId: Record<string, number>;
+  inUseStockAmountByBatchId: Record<string, number>;
   changeDishes: (nextDishes: EditorDish[]) => void;
   openFridgeItemSearch?: (currentItemId: string, onSelectId: (id: string) => void) => void;
+  openBatchSelect?: (fridgeItemId: string, onSelectBatchId: (batchId: string) => void) => void;
 }
 
 const [MealEditorProvider, useMealEditorContext] =

--- a/src/features/meal/model/schema.ts
+++ b/src/features/meal/model/schema.ts
@@ -9,17 +9,17 @@ import {
   validateAmountPrecisionByUnit,
 } from '@/entities/ingredient';
 
-import { formatIngredientAmountInfo, type FridgeStockInfo } from '../lib';
+import { formatIngredientAmountInfo, type FridgeBatchInfo } from '../lib';
 
 import { addAmount, isGreaterAmount, normalizeAmount } from './amount';
 
 /**
- * @description 식단 편집 폼의 dishes 배열 검증 스키마를 생성합니다.
+ * @description 식단 편집 폼의 dishes 배열 검증 스키마를 생성합니다. (배치 단위)
  */
 function createMealEditorDishesSchema(
   maxIngredientCount: number,
-  fridgeStockInfoById: Record<string, FridgeStockInfo>,
-  inUseStockAmountByItemId: Record<string, number>,
+  fridgeBatchInfoById: Record<string, FridgeBatchInfo>,
+  inUseStockAmountByBatchId: Record<string, number>,
 ) {
   return z
     .array(
@@ -36,8 +36,9 @@ function createMealEditorDishesSchema(
                 .string()
                 .trim()
                 .min(1, ERROR_MSG.SELECT.REQUIRED({ fieldName: '재료' })),
+              batch_id: z.string().trim(),
               amount: z.number().min(0, ERROR_MSG.RANGE.MIN({ fieldName: '재료 수량', min: 0 })),
-              usage_status: z.enum(['used', 'depleted', 'depleted_batch']),
+              usage_status: z.enum(['used', 'depleted']),
             }),
           )
           .min(1, '메뉴마다 재료를 1개 이상 추가해 주세요'),
@@ -45,7 +46,7 @@ function createMealEditorDishesSchema(
     )
     .min(1, '메뉴를 1개 이상 추가해 주세요')
     .superRefine((parsedDishes, ctx) => {
-      const usedAmountByItemId: Record<string, number> = {};
+      const usedAmountByBatchId: Record<string, number> = {};
 
       parsedDishes.forEach((dish, dishIndex) => {
         const dishLabel = dish.name.trim() || `메뉴 ${dishIndex + 1}`;
@@ -58,48 +59,60 @@ function createMealEditorDishesSchema(
           });
         }
 
-        const usedFridgeItemIds = new Set<string>();
+        const usedBatchIds = new Set<string>();
         dish.ingredients.forEach((ingredient, ingredientIndex) => {
-          if (usedFridgeItemIds.has(ingredient.fridge_item_id)) {
+          // 재료는 선택했지만 배치(구매분)를 고르지 않은 경우
+          if (ingredient.fridge_item_id && !ingredient.batch_id) {
             ctx.addIssue({
               code: 'custom',
-              message: `${dishLabel}에 같은 재료를 중복으로 선택할 수 없습니다`,
-              path: [dishIndex, 'ingredients', ingredientIndex, 'fridge_item_id'],
+              message: `${dishLabel}의 재료에서 구매분(재고)을 선택해 주세요`,
+              path: [dishIndex, 'ingredients', ingredientIndex, 'batch_id'],
             });
             return;
           }
 
-          usedFridgeItemIds.add(ingredient.fridge_item_id);
-          const stockInfo = fridgeStockInfoById[ingredient.fridge_item_id];
-          if (!stockInfo) return;
+          if (!ingredient.batch_id) return;
+
+          if (usedBatchIds.has(ingredient.batch_id)) {
+            ctx.addIssue({
+              code: 'custom',
+              message: `${dishLabel}에 같은 구매분을 중복으로 선택할 수 없습니다`,
+              path: [dishIndex, 'ingredients', ingredientIndex, 'batch_id'],
+            });
+            return;
+          }
+
+          usedBatchIds.add(ingredient.batch_id);
+          const batchInfo = fridgeBatchInfoById[ingredient.batch_id];
+          if (!batchInfo) return;
 
           // g/kg, ml/L 단위는 usage_status로 처리 — amount 검증 건너뜀
-          if (isWeightUnit(stockInfo.unit) || isVolumeUnit(stockInfo.unit)) return;
+          if (isWeightUnit(batchInfo.unit) || isVolumeUnit(batchInfo.unit)) return;
 
-          const minAmount = resolveAmountMin(stockInfo.unit);
+          const minAmount = resolveAmountMin(batchInfo.unit);
           if (ingredient.amount < minAmount) {
             ctx.addIssue({
               code: 'custom',
-              message: `${dishLabel}의 ${stockInfo.itemName} 수량은 ${minAmount}${stockInfo.unitLabel} 이상이어야 합니다`,
+              message: `${dishLabel}의 ${batchInfo.itemName} 수량은 ${minAmount}${batchInfo.unitLabel} 이상이어야 합니다`,
               path: [dishIndex, 'ingredients', ingredientIndex, 'amount'],
             });
             return;
           }
 
-          if (!validateAmountPrecisionByUnit(ingredient.amount, stockInfo.unit)) {
+          if (!validateAmountPrecisionByUnit(ingredient.amount, batchInfo.unit)) {
             ctx.addIssue({
               code: 'custom',
-              message: `${dishLabel}의 ${stockInfo.itemName} 수량은 정수만 입력할 수 있습니다`,
+              message: `${dishLabel}의 ${batchInfo.itemName} 수량은 정수만 입력할 수 있습니다`,
               path: [dishIndex, 'ingredients', ingredientIndex, 'amount'],
             });
             return;
           }
-          const inUseStockAmount = inUseStockAmountByItemId[ingredient.fridge_item_id] ?? 0;
-          // 보유 재고 + 사용 중인 재고
-          const maxAvailableAmount = addAmount(stockInfo.availableAmount, inUseStockAmount);
-          const accumulatedAmount = usedAmountByItemId[ingredient.fridge_item_id] ?? 0;
+          const inUseStockAmount = inUseStockAmountByBatchId[ingredient.batch_id] ?? 0;
+          // 배치 잔여 재고 + 이 식단이 이미 사용 중인 재고
+          const maxAvailableAmount = addAmount(batchInfo.quantity, inUseStockAmount);
+          const accumulatedAmount = usedAmountByBatchId[ingredient.batch_id] ?? 0;
           const nextAccumulatedAmount = addAmount(accumulatedAmount, ingredient.amount);
-          usedAmountByItemId[ingredient.fridge_item_id] = nextAccumulatedAmount;
+          usedAmountByBatchId[ingredient.batch_id] = nextAccumulatedAmount;
 
           const normalizedMaxAvailableAmount = normalizeAmount(maxAvailableAmount);
           const normalizedNextAccumulatedAmount = normalizeAmount(nextAccumulatedAmount);
@@ -107,7 +120,7 @@ function createMealEditorDishesSchema(
           if (isGreaterAmount(normalizedNextAccumulatedAmount, normalizedMaxAvailableAmount)) {
             ctx.addIssue({
               code: 'custom',
-              message: `${dishLabel}의 ${stockInfo.itemName}은 ${formatIngredientAmountInfo(normalizedMaxAvailableAmount, stockInfo.unit)}를 초과할 수 없습니다`,
+              message: `${dishLabel}의 ${batchInfo.itemName}은 ${formatIngredientAmountInfo(normalizedMaxAvailableAmount, batchInfo.unit)}를 초과할 수 없습니다`,
               path: [dishIndex, 'ingredients', ingredientIndex, 'amount'],
             });
           }

--- a/src/features/meal/ui/FridgeBatchSelectScreen.tsx
+++ b/src/features/meal/ui/FridgeBatchSelectScreen.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { AppScreen } from '@stackflow/plugin-basic-ui';
+import { format, parseISO } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+import { type IngredientUnit } from '@/entities/ingredient';
+
+import { formatIngredientAmountInfo, type FridgeBatchSelectOption } from '../lib';
+
+interface FridgeBatchSelectScreenProps {
+  /** 화면 닫기 핸들러 (Activity에서 주입) */
+  onClose: () => void;
+  /** 배치 선택 핸들러 — 선택된 batch_id를 반환한다 (Activity에서 주입) */
+  onSelectBatch: (batchId: string) => void;
+  /** 선택 가능한 배치(구매분) 목록 — 잔여 재고가 있는 배치만 */
+  batches?: FridgeBatchSelectOption[];
+  /** 냉장고 품목 단위 — 잔여 수량 표시용 */
+  unit?: IngredientUnit;
+}
+
+/** 식단 배치(구매분) 선택 전용 Screen — 한 품목의 여러 구매분 중 하나를 선택한다 */
+export function FridgeBatchSelectScreen({
+  onClose: _onClose,
+  onSelectBatch,
+  batches = [],
+  unit,
+}: FridgeBatchSelectScreenProps) {
+  return (
+    <AppScreen className="pointer-events-auto" appBar={{ title: '구매분 선택' }}>
+      <div className="flex flex-col gap-0">
+        <p className="px-4 pt-3 pb-1 text-xs text-gray-400">
+          오래된 구매분부터 표시됩니다. 소진/차감은 선택한 구매분에만 적용돼요.
+        </p>
+
+        {batches.length > 0 ? (
+          <ul className="divide-y divide-gray-100">
+            {batches.map((batch) => (
+              <li key={batch.id}>
+                <button
+                  type="button"
+                  onClick={() => onSelectBatch(batch.id)}
+                  className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left hover:bg-gray-50 active:bg-gray-100"
+                >
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate text-sm text-gray-900">
+                      {format(parseISO(batch.purchasedDate), 'yyyy.M.d', { locale: ko })} 구매
+                    </span>
+                    {batch.expiryDate ? (
+                      <span className="truncate text-xs text-gray-400">
+                        유통기한 {format(parseISO(batch.expiryDate), 'yyyy.M.d', { locale: ko })}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="shrink-0 text-sm font-medium text-gray-700">
+                    {formatIngredientAmountInfo(Number(batch.quantity), unit)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="flex flex-col items-center py-12 text-sm text-gray-400">
+            <p>선택 가능한 구매분이 없습니다</p>
+          </div>
+        )}
+      </div>
+    </AppScreen>
+  );
+}

--- a/src/features/meal/ui/MealDishCard.tsx
+++ b/src/features/meal/ui/MealDishCard.tsx
@@ -11,6 +11,7 @@ import {
   type IngredientUsageStatus,
   renameDish,
   replaceIngredientAmount,
+  replaceIngredientBatch,
   replaceIngredientItem,
   replaceIngredientUsageStatus,
 } from '../lib';
@@ -23,7 +24,8 @@ interface MealDishCardProps {
 }
 
 function MealDishCard({ dishIndex }: MealDishCardProps) {
-  const { dishes, fridgeItems, changeDishes } = useMealEditorContext('MealDishCard');
+  const { dishes, fridgeItems, changeDishes, openBatchSelect } =
+    useMealEditorContext('MealDishCard');
   const dish = dishes[dishIndex];
   if (!dish) return null;
 
@@ -62,26 +64,54 @@ function MealDishCard({ dishIndex }: MealDishCardProps) {
             onIngredientItemChange={(value) => {
               let nextDishes = replaceIngredientItem(dishes, dishIndex, ingredientIndex, value);
               const selectedItem = fridgeItems.find((item) => item.id === value);
-              if (selectedItem) {
-                nextDishes = nextDishes.map((dish, di) =>
-                  di !== dishIndex
-                    ? dish
-                    : {
-                        ...dish,
-                        ingredients: dish.ingredients.map((ing, ii) =>
-                          ii !== ingredientIndex
-                            ? ing
-                            : {
-                                ...ing,
-                                unit: selectedItem.unit,
-                                usage_status: 'used' as const,
-                              },
-                        ),
-                      },
+
+              if (!selectedItem) {
+                changeDishes(nextDishes);
+                return;
+              }
+
+              // 선택 품목 단위 주입
+              nextDishes = nextDishes.map((currentDish, di) =>
+                di !== dishIndex
+                  ? currentDish
+                  : {
+                      ...currentDish,
+                      ingredients: currentDish.ingredients.map((ing, ii) =>
+                        ii !== ingredientIndex ? ing : { ...ing, unit: selectedItem.unit },
+                      ),
+                    },
+              );
+
+              const selectableBatches = selectedItem.fridge_item_batches.filter(
+                (batch) => Number(batch.quantity) > 0,
+              );
+              const [firstBatch] = selectableBatches;
+
+              // 배치가 1개뿐이면 자동 지정
+              if (selectableBatches.length === 1 && firstBatch) {
+                nextDishes = replaceIngredientBatch(
+                  nextDishes,
+                  dishIndex,
+                  ingredientIndex,
+                  firstBatch.id,
                 );
               }
+
               changeDishes(nextDishes);
+
+              // 배치가 2개 이상이면 선택 화면으로 진입
+              if (selectableBatches.length >= 2 && openBatchSelect) {
+                const committedDishes = nextDishes;
+                openBatchSelect(value, (batchId) =>
+                  changeDishes(
+                    replaceIngredientBatch(committedDishes, dishIndex, ingredientIndex, batchId),
+                  ),
+                );
+              }
             }}
+            onIngredientBatchChange={(batchId) =>
+              changeDishes(replaceIngredientBatch(dishes, dishIndex, ingredientIndex, batchId))
+            }
             onIngredientAmountChange={(value) =>
               changeDishes(replaceIngredientAmount(dishes, dishIndex, ingredientIndex, value))
             }

--- a/src/features/meal/ui/MealEditorScreen.tsx
+++ b/src/features/meal/ui/MealEditorScreen.tsx
@@ -11,16 +11,23 @@ import { z } from 'zod';
 import { extractFieldErrorMessage } from '@/commons/lib';
 import { Button, CTAButton, CTAConfirmButton, DeleteConfirmBottomSheet, Toast } from '@/commons/ui';
 
+import { type IngredientUnit } from '@/entities/ingredient';
 import { type Meal, type MealType } from '@/entities/meal';
 
 import { useDeleteMealMutation, useUpsertMealMutation } from '../api/mutations';
 import { useFridgeItemsForMealQuery } from '../api/queries';
-import { appendDish, createFridgeStockInfoById, type FridgeItemSearchOption } from '../lib';
 import {
-  createInUseStockAmountByItemId,
+  appendDish,
+  createFridgeBatchInfoById,
+  type FridgeBatchSelectOption,
+  type FridgeItemSearchOption,
+} from '../lib';
+import {
+  createInUseStockAmountByBatchId,
   createMealEditorDishesSchema,
   MealEditorProvider,
   toEditorDishes,
+  toMealFridgeItems,
 } from '../model';
 
 import { MealDishCard } from './MealDishCard';
@@ -35,6 +42,12 @@ interface MealEditorScreenProps {
   onOpenFridgeItemSearch?: (
     items: FridgeItemSearchOption[],
     onSelectId: (fridgeItemId: string) => void,
+  ) => void;
+  /** 배치 선택 Screen 진입 핸들러 — 선택된 batch_id가 그대로 반영된다 */
+  onOpenFridgeBatchSelect?: (
+    batches: FridgeBatchSelectOption[],
+    unit: IngredientUnit,
+    onSelectBatchId: (batchId: string) => void,
   ) => void;
 }
 
@@ -63,6 +76,7 @@ export function MealEditorScreen({
   type,
   meal,
   onOpenFridgeItemSearch,
+  onOpenFridgeBatchSelect,
 }: MealEditorScreenProps) {
   /* -------------------------------------------------------------------------- */
   /* Header Constants                                                            */
@@ -79,18 +93,22 @@ export function MealEditorScreen({
     ),
   ].filter(Boolean);
 
-  const { data: fridgeItems = [] } = useFridgeItemsForMealQuery(householdId, selectedFridgeItemIds);
+  const { data: fridgeItemOptions = [] } = useFridgeItemsForMealQuery(
+    householdId,
+    selectedFridgeItemIds,
+  );
+  const fridgeItems = toMealFridgeItems(fridgeItemOptions);
   const upsertMutation = useUpsertMealMutation();
   const deleteMutation = useDeleteMealMutation();
 
   const maxIngredientCount = fridgeItems.length;
-  const fridgeStockInfoById = createFridgeStockInfoById(fridgeItems);
-  const inUseStockAmountByItemId = createInUseStockAmountByItemId(initialDishes);
+  const fridgeBatchInfoById = createFridgeBatchInfoById(fridgeItems);
+  const inUseStockAmountByBatchId = createInUseStockAmountByBatchId(initialDishes);
   const mealEditorFormSchema = z.object({
     dishes: createMealEditorDishesSchema(
       maxIngredientCount,
-      fridgeStockInfoById,
-      inUseStockAmountByItemId,
+      fridgeBatchInfoById,
+      inUseStockAmountByBatchId,
     ),
   });
 
@@ -190,6 +208,23 @@ export function MealEditorScreen({
     onOpenFridgeItemSearch(items, onSelectId);
   }
 
+  function openBatchSelect(fridgeItemId: string, onSelectBatchId: (batchId: string) => void) {
+    if (!onOpenFridgeBatchSelect) return;
+    const item = fridgeItems.find((fridgeItem) => fridgeItem.id === fridgeItemId);
+    if (!item) return;
+
+    const batches: FridgeBatchSelectOption[] = item.fridge_item_batches
+      .filter((batch) => Number(batch.quantity) > 0)
+      .map((batch) => ({
+        id: batch.id,
+        purchasedDate: batch.purchased_date,
+        quantity: Number(batch.quantity),
+        expiryDate: batch.expiry_date,
+      }));
+
+    onOpenFridgeBatchSelect(batches, item.unit, onSelectBatchId);
+  }
+
   return (
     <AppScreen className="pointer-events-auto" appBar={{ title: appBarTitle }}>
       <div className="space-y-3 px-4 pt-4 pb-28">
@@ -198,9 +233,10 @@ export function MealEditorScreen({
             <MealEditorProvider
               dishes={field.state.value}
               fridgeItems={fridgeItems}
-              inUseStockAmountByItemId={inUseStockAmountByItemId}
+              inUseStockAmountByBatchId={inUseStockAmountByBatchId}
               changeDishes={field.handleChange}
               openFridgeItemSearch={onOpenFridgeItemSearch ? openFridgeItemSearch : undefined}
+              openBatchSelect={onOpenFridgeBatchSelect ? openBatchSelect : undefined}
             >
               <div className="space-y-3">
                 {field.state.value.map((_, dishIndex) => (

--- a/src/features/meal/ui/MealIngredientRow.tsx
+++ b/src/features/meal/ui/MealIngredientRow.tsx
@@ -1,15 +1,18 @@
 'use client';
 
+import { format, parseISO } from 'date-fns';
 import { ChevronRight, X } from 'lucide-react';
 
-import { Badge, Button, SegmentControl, Select } from '@/commons/ui';
+import { Badge, Button, Checkbox, Select } from '@/commons/ui';
 import { cn } from '@/commons/lib';
 
-import { isVolumeUnit, isWeightUnit } from '@/entities/ingredient';
+import { isVolumeUnit, isWeightUnit, type IngredientUnit } from '@/entities/ingredient';
 
 import {
   type EditorIngredient,
+  formatIngredientAmountInfo,
   type IngredientUsageStatus,
+  type MealFridgeBatch,
   resolveSliderBoundaries,
   resolveWeightSliderMin,
   resolveWeightSliderStep,
@@ -21,50 +24,64 @@ import { MealIngredientWeightControl } from './MealIngredientWeightControl';
 interface MealIngredientRowProps {
   ingredient: EditorIngredient;
   onIngredientItemChange: (value: string) => void;
+  onIngredientBatchChange: (batchId: string) => void;
   onIngredientAmountChange: (value: string) => void;
   onUsageStatusChange: (status: IngredientUsageStatus) => void;
   onIngredientRemove: () => void;
 }
 
+/**
+ * @description 배치(구매분) 정보를 "M.d 구매 · 잔여수량" 형태로 표시합니다.
+ */
+function formatBatchLabel(batch: MealFridgeBatch, unit: IngredientUnit | undefined) {
+  const purchasedLabel = format(parseISO(batch.purchased_date), 'M.d');
+  return `${purchasedLabel} 구매 · ${formatIngredientAmountInfo(Number(batch.quantity), unit)}`;
+}
+
 function MealIngredientRow({
   ingredient,
   onIngredientItemChange,
+  onIngredientBatchChange,
   onIngredientAmountChange,
   onUsageStatusChange,
   onIngredientRemove,
 }: MealIngredientRowProps) {
-  const { fridgeItems, inUseStockAmountByItemId, openFridgeItemSearch } =
+  const { fridgeItems, inUseStockAmountByBatchId, openFridgeItemSearch, openBatchSelect } =
     useMealEditorContext('MealIngredientRow');
 
   /* -------------------------------------------------------------------------- */
   /* Selection Constants                                                         */
   /* -------------------------------------------------------------------------- */
   const selectedIngredient = fridgeItems.find((item) => item.id === ingredient.fridge_item_id);
-  const inUseStockAmount = selectedIngredient
-    ? (inUseStockAmountByItemId[selectedIngredient.id] ?? 0)
-    : 0;
-  const selectedRemainingAmount = selectedIngredient ? Number(selectedIngredient.total_count) : NaN;
-  const selectedMaxAvailableAmount = Number.isFinite(selectedRemainingAmount)
-    ? selectedRemainingAmount + inUseStockAmount
-    : selectedIngredient?.total_count;
+  const selectedUnit = selectedIngredient?.unit;
+  const selectableBatches =
+    selectedIngredient?.fridge_item_batches.filter((batch) => Number(batch.quantity) > 0) ?? [];
+  const hasMultipleBatches = selectableBatches.length >= 2;
+  const selectedBatch = selectedIngredient?.fridge_item_batches.find(
+    (batch) => batch.id === ingredient.batch_id,
+  );
 
   /* -------------------------------------------------------------------------- */
-  /* Unit / Range Constants                                                      */
+  /* Amount / Range Constants (개 단위 — 선택 배치 잔여 기준)                     */
   /* -------------------------------------------------------------------------- */
-  const selectedUnit = selectedIngredient?.unit;
-  const sliderBoundary = resolveSliderBoundaries(selectedMaxAvailableAmount);
+  const inUseStockAmount = ingredient.batch_id
+    ? (inUseStockAmountByBatchId[ingredient.batch_id] ?? 0)
+    : 0;
+  const batchRemaining = selectedBatch ? Number(selectedBatch.quantity) : NaN;
+  const maxAvailableAmount = Number.isFinite(batchRemaining)
+    ? batchRemaining + inUseStockAmount
+    : selectedBatch?.quantity;
+
+  const sliderBoundary = resolveSliderBoundaries(maxAvailableAmount);
   const sliderStep = resolveWeightSliderStep(selectedUnit);
   const sliderMin = resolveWeightSliderMin(selectedUnit);
-
-  /* -------------------------------------------------------------------------- */
-  /* Display / Control Constants                                                 */
-  /* -------------------------------------------------------------------------- */
   const sliderValue = ingredient.amount > 0 ? ingredient.amount : sliderMin;
   const selectedAmount = Math.min(Math.max(sliderValue, sliderMin), sliderBoundary.max);
-  const isAmountControlDisabled = !selectedIngredient || sliderBoundary.max < 1;
-  const ingredientSelectValue = ingredient.fridge_item_id;
+  const isAmountControlDisabled = !selectedBatch || sliderBoundary.max < 1;
 
-  const isDepleted = selectedIngredient ? Number(selectedIngredient.total_count) <= 0 : false;
+  const ingredientSelectValue = ingredient.fridge_item_id;
+  const isItemDepleted = selectedIngredient ? Number(selectedIngredient.total_count) <= 0 : false;
+  const isUsageStatusUnit = isWeightUnit(selectedUnit) || isVolumeUnit(selectedUnit);
 
   return (
     <div className="space-y-2.5">
@@ -90,7 +107,7 @@ function MealIngredientRow({
               ) : (
                 <span className="truncate">재료 선택</span>
               )}
-              {isDepleted ? (
+              {isItemDepleted ? (
                 <Badge
                   variant="outline"
                   className="shrink-0 border-red-200 bg-red-50 px-1.5 py-0 text-[10px] text-red-600"
@@ -108,16 +125,16 @@ function MealIngredientRow({
             </Select.Trigger>
             <Select.Content>
               {fridgeItems.map((item) => {
-                const isItemDepleted = Number(item.total_count) <= 0;
+                const itemDepleted = Number(item.total_count) <= 0;
 
                 return (
-                  <Select.Item key={item.id} value={item.id} disabled={isItemDepleted}>
+                  <Select.Item key={item.id} value={item.id} disabled={itemDepleted}>
                     <span className="flex items-center gap-1.5">
                       <span>
                         {item.name}
                         {item.brand ? <span className="text-gray-400"> ({item.brand})</span> : null}
                       </span>
-                      {isItemDepleted ? (
+                      {itemDepleted ? (
                         <Badge
                           variant="outline"
                           className="border-red-200 bg-red-50 px-1.5 py-0 text-[10px] text-red-600"
@@ -145,20 +162,36 @@ function MealIngredientRow({
         </Button>
       </div>
 
-      {isWeightUnit(selectedUnit) || isVolumeUnit(selectedUnit) ? (
-        <div className="space-y-1">
-          <SegmentControl
-            size="sm"
-            value={ingredient.usage_status}
-            onValueChange={(value) => onUsageStatusChange(value as IngredientUsageStatus)}
-            disabled={!selectedIngredient}
+      {/* 배치(구매분) 선택/표시 */}
+      {selectedIngredient ? (
+        <BatchRow
+          batch={selectedBatch}
+          unit={selectedUnit}
+          selectable={hasMultipleBatches && Boolean(openBatchSelect)}
+          onOpen={() => openBatchSelect?.(ingredient.fridge_item_id, onIngredientBatchChange)}
+        />
+      ) : null}
+
+      {isUsageStatusUnit ? (
+        <label
+          className={cn(
+            'flex cursor-pointer items-center gap-2',
+            !selectedBatch && 'cursor-not-allowed',
+          )}
+        >
+          <Checkbox
+            checked={ingredient.usage_status === 'depleted'}
+            onCheckedChange={(checked) =>
+              onUsageStatusChange(checked === true ? 'depleted' : 'used')
+            }
+            disabled={!selectedBatch}
+          />
+          <span
+            className={cn('text-sm', !selectedBatch ? 'text-muted-foreground' : 'text-gray-700')}
           >
-            <SegmentControl.Item value="used">사용</SegmentControl.Item>
-            <SegmentControl.Item value="depleted_batch">일부 소진</SegmentControl.Item>
-            <SegmentControl.Item value="depleted">전량 소진</SegmentControl.Item>
-          </SegmentControl>
-          <p className="text-xs text-gray-400">‘일부 소진’은 가장 오래된 구매분 하나만 비워요.</p>
-        </div>
+            소진됨
+          </span>
+        </label>
       ) : (
         <MealIngredientWeightControl
           min={sliderMin}
@@ -172,6 +205,40 @@ function MealIngredientRow({
       )}
     </div>
   );
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * BatchRow
+ * -----------------------------------------------------------------------------------------------*/
+
+interface BatchRowProps {
+  batch: MealFridgeBatch | undefined;
+  unit: IngredientUnit | undefined;
+  selectable: boolean;
+  onOpen: () => void;
+}
+
+function BatchRow({ batch, unit, selectable, onOpen }: BatchRowProps) {
+  // 배치가 여러 개라 선택이 필요한 경우
+  if (selectable) {
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        className="flex w-full items-center justify-between gap-1.5 rounded-md bg-gray-50 px-3 py-1.5 text-left text-xs text-gray-600 hover:bg-gray-100"
+      >
+        <span className="truncate">{batch ? formatBatchLabel(batch, unit) : '구매분 선택'}</span>
+        <ChevronRight className="ml-1 size-3.5 shrink-0 text-gray-400" />
+      </button>
+    );
+  }
+
+  // 배치가 하나뿐이라 선택 불필요 — 정보만 표시
+  if (batch) {
+    return <p className="px-1 text-xs text-gray-400">{formatBatchLabel(batch, unit)}</p>;
+  }
+
+  return null;
 }
 
 export { MealIngredientRow };

--- a/supabase/migrations/072_add_batch_id_to_dish_ingredients.sql
+++ b/supabase/migrations/072_add_batch_id_to_dish_ingredients.sql
@@ -1,13 +1,30 @@
--- Function: public.upsert_meal_with_usage
--- Source: supabase/migrations/072_add_batch_id_to_dish_ingredients.sql
--- 역할: 식단 저장 시 dish/ingredient와 배치 사용량 차감을 원자적으로 처리합니다.
+-- Migration: 072_add_batch_id_to_dish_ingredients
+-- 역할: 식단 재료를 특정 배치(구매분) 단위로 지정하도록 바꾸고, 소진/차감을 그 배치에만 적용합니다.
 -- 동작:
--- 1. 기존 meal usage를 롤백한 뒤 새 dishes/ingredients를 재저장합니다.
--- 2. usage_status='used' (g/kg·ml/L): dish_ingredients에만 기록, 배치 변화 없음.
--- 3. usage_status='depleted' (g/kg·ml/L): 지정된 batch_id 배치를 0으로 소진, meal_batch_usages 기록.
--- 4. amount>0 (개): 지정된 batch_id 배치에서만 차감(FIFO 아님), 부족 시 도메인 예외 발생.
--- 5. 각 재료 줄은 batch_id로 특정 구매분을 지정한다 (같은 품목도 배치별로 여러 줄 가능).
--- 6. meals 테이블에 created_by(auth.uid())를 기록합니다 (신규 등록 시에만, 수정 시 유지).
+-- 1. dish_ingredients.batch_id 컬럼을 추가합니다 (fridge_item_batches FK, 배치 삭제 시 NULL).
+-- 2. usage_status CHECK 제약을 다시 'used' | 'depleted'로 되돌립니다 (depleted_batch 제거).
+-- 3. upsert_meal_with_usage RPC를 재작성해 지정된 batch_id에만 소진/차감을 적용합니다.
+--    - g/kg·ml/L usage_status='depleted': 지정 배치 quantity→0
+--    - 개 단위 amount>0: 지정 배치에서만 차감(FIFO 아님), 부족 시 도메인 예외
+--    - usage_status='used': dish_ingredients 기록만, 배치 변화 없음
+
+-- Step 1: batch_id 컬럼 추가
+ALTER TABLE public.dish_ingredients
+  ADD COLUMN IF NOT EXISTS batch_id uuid
+  REFERENCES public.fridge_item_batches(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS dish_ingredients_batch_id_idx
+  ON public.dish_ingredients(batch_id);
+
+-- Step 2: usage_status CHECK 제약 원복 ('used' | 'depleted')
+ALTER TABLE public.dish_ingredients
+  DROP CONSTRAINT IF EXISTS dish_ingredients_usage_status_check;
+
+ALTER TABLE public.dish_ingredients
+  ADD CONSTRAINT dish_ingredients_usage_status_check
+  CHECK (usage_status IN ('used', 'depleted'));
+
+-- Step 3: RPC 재작성
 create or replace function public.upsert_meal_with_usage(
   p_household_id uuid,
   p_date date,


### PR DESCRIPTION
# Pull Request

## Pull Request Type

- [x] feat: 기능 구현 (새로운 요구사항 구현, 기존 기능 개선)
- [ ] fix: 버그 수정
- [ ] refactor: 코드 리팩토링
  > 성능 개선, 구조 변경, 기능 수정 없을 때
- [ ] style: 포매팅, 린트 (기능 변화 없음)
- [ ] chore: 환경설정, 패키지 관리, 라이브러리 설치 등
- [ ] docs: 문서 작성

## 관련 이슈

<!-- 없음 -->

## 작업 내용

기존에는 식단에서 g/kg 재료 소진 시 해당 품목의 **모든 배치(구매분)** 가 함께 사라져, 냉장고 재고분과 장보기분이 같은 품목으로 합쳐진 경우 의도치 않게 둘 다 소진되는 문제가 있었습니다. 이를 **재료를 배치(구매분) 단위로 지정**하고, 소진/차감을 **선택한 배치에만** 적용하도록 바꿨습니다.

### 데이터 모델 (`migration 072`)
- `dish_ingredients.batch_id` 컬럼 추가 (`fridge_item_batches` FK, 배치 삭제 시 `NULL`) + 인덱스
- `usage_status` CHECK 제약을 `used | depleted`로 복귀 (직전 PR의 `depleted_batch` 제거)
- `upsert_meal_with_usage` RPC 재작성
  - `depleted`(g/kg·ml/L): 지정된 `batch_id` 배치만 `quantity → 0`
  - `amount > 0`(개): 지정된 배치에서만 차감 (FIFO 자동 선택 제거), 부족 시 도메인 예외
  - 소스 함수 파일(`supabase/sql/functions/.../upsert_meal_with_usage.sql`) 동기화

### 조회 / 저장
- `GET /api/meals/fridge-items`: 배치 `id·expiry_date` 포함, 삭제 배치 제외 + 구매일순 정렬
- `GET /api/meals`: `dish_ingredients.batch_id` + 선택 배치 조인
- `POST /api/meals`: `batch_id` 전달

### 앱 (배치 단위 회계로 전환)
- 재고 검증·수량 슬라이더 상한을 품목 `total_count` → **선택 배치 잔여 수량** 기준으로 변경 (in-use 맵도 배치 키 기반)
- 재료 한 줄 = 한 배치. 중복 검사도 배치 기준, 배치 미선택 시 저장 차단
- `SegmentControl(사용/일부/전량)` → **"소진됨" 체크박스**로 복귀하고 선택 배치(구매일·잔여) 표시
- 재료 선택 후 **배치가 2개 이상이면 Stackflow 배치 선택 화면**으로 진입, **1개면 자동 지정**
- `FridgeBatchSelectScreen` + Activity + route(`/search/fridge-batch`) + 콜백 스토어 추가

### 참고
- `batch_id`는 nullable — 기존 식단 데이터(구버전 행)는 `batch_id = null`로 남고, 해당 식단을 다시 저장하면 배치 지정 방식으로 갱신됩니다.
- 삭제 시 재고 복구(`delete_meal_with_usage_restore`)와 냉장고 목록의 `has_meal_usage` 판정은 각각 `meal_batch_usages`·`dish_ingredients` 기준이라 새 모델에서도 그대로 동작합니다.

## 검증

- `pnpm lint` (ESLint + tsc) 통과 — 남은 경고 1건은 이번 변경과 무관한 기존 `FridgeBatchForm.tsx`
- 마이그레이션 `072`는 아직 운영 DB 미적용 상태이며, 적용 후 `/meal` 플로우 스모크 테스트 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019oNoAx1Gmzd7LBTToga1ZW)_